### PR TITLE
Bug: Clojars artifact missing dependencies

### DIFF
--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -3,5 +3,5 @@
 (def ws-schema-version {:breaking 0
                         :non-breaking 0})
 
-(def version "0.1.0-alpha6")
-(def date "2020-11-26")
+(def version "0.1.0-alpha7")
+(def date "2020-12-01")

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -25,7 +25,7 @@ poly help
 ```
 
 ```
-  Poly 0.1.0-alpha6 (2020-11-26) - https://github.com/polyfy/polylith
+  Poly 0.1.0-alpha7 (2020-12-01) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/projects/api/partial_pom.xml
+++ b/projects/api/partial_pom.xml
@@ -24,6 +24,11 @@
       <version>0.8.695</version>
     </dependency>
     <dependency>
+      <groupId>metosin</groupId>
+      <artifactId>malli</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>me.raynes</groupId>
       <artifactId>fs</artifactId>
       <version>1.4.6</version>

--- a/projects/poly-migrator/deps.edn
+++ b/projects/poly-migrator/deps.edn
@@ -16,7 +16,7 @@
            :aot     {:extra-paths ["classes"]
                      :main-opts   ["-e" "(compile,'polylith.clj.core.migrator-cli.core)"]}
 
-           :uberjar {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
+           :uberjar {:extra-deps {uberdeps/uberdeps {:mvn/version "0.1.10"}}
                      :main-opts  ["-m" "uberdeps.uberjar"
                                   "--aliases" "aot"
                                   "--main-class" "polylith.clj.core.migrator_cli.core"

--- a/projects/poly/deps.edn
+++ b/projects/poly/deps.edn
@@ -51,7 +51,7 @@
            :aot       {:extra-paths ["classes"]
                        :main-opts   ["-e" "(compile,'polylith.clj.core.poly-cli.core)"]}
 
-           :uberjar   {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
+           :uberjar   {:extra-deps {uberdeps/uberdeps {:mvn/version "0.1.10"}}
                        :main-opts  ["-m" "uberdeps.uberjar"
                                     "--aliases" "aot"
                                     "--main-class" "polylith.clj.core.poly_cli.core"]}

--- a/projects/poly/partial_pom.xml
+++ b/projects/poly/partial_pom.xml
@@ -34,6 +34,11 @@
       <version>0.8.695</version>
     </dependency>
     <dependency>
+      <groupId>metosin</groupId>
+      <artifactId>malli</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>me.raynes</groupId>
       <artifactId>fs</artifactId>
       <version>1.4.6</version>

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ name and email.
 To install the `poly` command on Linux:
 
 - Download the [latest release](https://github.com/polyfy/polylith/releases/latest) of the `poly` jar,
-  e.g. `poly-0.1.0-alpha6.jar`.
+  e.g. `poly-0.1.0-alpha7.jar`.
 - Create a directory, e.g. `/usr/local/polylith` and copy the jar file to that directory.
 - Create a file with the name `poly` and put it in e.g. `/usr/local/bin` with this content:
  ```
@@ -149,7 +149,7 @@ while [ "$1" != "" ] ; do
   shift
 done
 
-exec "/usr/bin/java" "-jar" "/usr/local/polylith/poly-0.1.0-alpha6.jar" $ARGS
+exec "/usr/bin/java" "-jar" "/usr/local/polylith/poly-0.1.0-alpha7.jar" $ARGS
 ```
 - Make sure that:
   - you point to the correct jar file.
@@ -193,13 +193,13 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 To install the `poly` command on Windows:
 
 - Download the [latest release](https://github.com/polyfy/polylith/releases/latest) of the `poly` jar,
-  e.g. `poly-0.1.0-alpha6.jar`.
+  e.g. `poly-0.1.0-alpha7.jar`.
 - Create the `Polylith` directory somewhere on your machine, e.g. 
   `C:\Program Files\Polylith` and copy the jar file to that directory.
 - Create the file `poly.bat` with this content (make sure you point to the jar):
 ```sh
 @echo off
-start /wait /b java -jar "C:\Program Files\Polylith\poly-0.1.0-alpha6.jar" %*
+start /wait /b java -jar "C:\Program Files\Polylith\poly-0.1.0-alpha7.jar" %*
 ```
 - Add `C:\Program Files\Polylith` to the Windows `PATH` variable.
 
@@ -218,7 +218,7 @@ To use it this way, add one of the following aliases to the `:aliases` section i
 {
 ...
  :aliases   {:poly  {:extra-deps {polylith/clj-poly
-                                  {:mvn/version "0.1.0-alpha6"}}
+                                  {:mvn/version "0.1.0-alpha7"}}
                      :main-opts  ["-m" "polylith.clj.core.poly-cli.core"]}}
 ...
 }
@@ -250,7 +250,7 @@ clj -M:poly info
 Similarly, you can use other artifacts from this repository, `clj-api` or `clj-poly-migrator` as dependencies. For example, in order to add `clj-api` as a dependency, add one of the following to your `:deps` section in your `deps.edn` file:
 
 ```clojure
-polylith/clj-api {:mvn/version "0.1.0-alpha6"}
+polylith/clj-api {:mvn/version "0.1.0-alpha7"}
 ```
 or
 ```clojure
@@ -2428,7 +2428,7 @@ poly ws get:settings
  :user-config-file "/Users/tengstrand/.polylith/config.edn",
  :user-home "/Users/tengstrand",
  :vcs "git",
- :version "0.1.0-alpha6",
+ :version "0.1.0-alpha7",
  :ws-schema-version {:breaking 0, :non-breaking 0}}
 ```
 


### PR DESCRIPTION
Fixes #60 
* Updated dependencies in pom.xml.
* Added qualified name for `uberdeps` dependency to get rid of Clojure cli warnings.
* Updated version to 0.10-alpha7