### PR TITLE
Changed how to retrieve git tags

### DIFF
--- a/components/git/src/polylith/clj/core/git/tag.clj
+++ b/components/git/src/polylith/clj/core/git/tag.clj
@@ -1,0 +1,29 @@
+(ns polylith.clj.core.git.tag
+  (:require [clojure.string :as str]
+            [polylith.clj.core.shell.interface :as shell]
+            [polylith.clj.core.util.interface.str :as str-util]))
+
+(defn log-lines [ws-dir]
+  (str/split-lines (shell/sh "git" "log" (str "--pretty=format:%H %d") :dir ws-dir)))
+
+(defn skip-tag [string]
+  (if (str/starts-with? string "tag: ")
+    (subs string 5)
+    string))
+
+(defn matching-tag [tag pattern]
+  (when (re-find (re-pattern pattern) tag)
+    tag))
+
+(defn tags [line pattern]
+  (when-let [string (str-util/take-until
+                      (str-util/skip-until line "tag: ") ")")]
+    (when-let [tag (first (filter identity
+                                  (map #(matching-tag (skip-tag %) pattern)
+                                       (str/split string #", "))))]
+      {:tag tag
+       :sha (subs line 0 40)})))
+
+(defn matching-tags [ws-dir pattern]
+  (filterv identity (map #(tags % pattern)
+                         (log-lines ws-dir))))

--- a/components/help/src/polylith/clj/core/help/diff.clj
+++ b/components/help/src/polylith/clj/core/help/diff.clj
@@ -15,7 +15,7 @@
        "\n"
        "  The pattern can be changed in " (color/purple color-mode ":stable-tag-pattern") " in ./deps.edn.\n"
        "\n"
-       "  The way the latest tag is found is by taking the first line that matches the 'table-*'\n"
+       "  The way the latest tag is found is by taking the first line that matches the 'stable-*'\n"
        "  regular expression, or if no match was found, the first commit in the repository.\n"
        "    git log --pretty=format:'%H %d'\n"
        "\n"

--- a/components/help/src/polylith/clj/core/help/diff.clj
+++ b/components/help/src/polylith/clj/core/help/diff.clj
@@ -15,8 +15,9 @@
        "\n"
        "  The pattern can be changed in " (color/purple color-mode ":stable-tag-pattern") " in ./deps.edn.\n"
        "\n"
-       "  The way the latest tag is found is by taking the last line of the output from:\n"
-       "    git tag --sort=committerdate -l 'stable-*'\n"
+       "  The way the latest tag is found is by taking the first line that matches the 'table-*'\n"
+       "  regular expression, or if no match was found, the first commit in the repository.\n"
+       "    git log --pretty=format:'%H %d'\n"
        "\n"
        "  Here is a compact way of listing all the commits including tags:\n"
        "    git log --pretty=oneline"))

--- a/components/util/src/polylith/clj/core/util/interface/str.clj
+++ b/components/util/src/polylith/clj/core/util/interface/str.clj
@@ -3,10 +3,11 @@
             [polylith.clj.core.util.str :as str-util]))
 
 (defn skip-if-ends-with [string ends-with]
-  (if (str/ends-with? string ends-with)
-    (let [chars (- (count string) (count ends-with))]
-      (subs string 0 chars))
-    string))
+  (when string
+    (if (str/ends-with? string ends-with)
+      (let [chars (- (count string) (count ends-with))]
+        (subs string 0 chars))
+      string)))
 
 (defn skip-until [string separator]
   (str-util/skip-until string separator))

--- a/components/util/src/polylith/clj/core/util/str.clj
+++ b/components/util/src/polylith/clj/core/util/str.clj
@@ -12,7 +12,7 @@
   (when string
     (let [index (str/index-of string separator)]
       (when index
-        (subs string (inc index))))))
+        (subs string (+ (count separator) index))))))
 
 (defn skip-prefix [string prefix]
   (when string

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -3,5 +3,5 @@
 (def ws-schema-version {:breaking 0
                         :non-breaking 0})
 
-(def version "0.1.0-alpha8")
-(def date "2020-12-02")
+(def version "0.1.0-alpha9")
+(def date "2020-12-23")

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -25,7 +25,7 @@ poly help
 ```
 
 ```
-  Poly 0.1.0-alpha8 (2020-12-02) - https://github.com/polyfy/polylith
+  Poly 0.1.0-alpha9 (2020-12-23) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/readme.md
+++ b/readme.md
@@ -1153,10 +1153,11 @@ git tag -f stable-lisa c91fdad
 
 The way the tool finds the latest tag is to execute this command internally:
 ```
-git tag --sort=committerdate -l 'stable-*'
-``` 
+git log --pretty=format:'%H %d'
+```
 
-Then it uses the last line of the output, or if no match was found, the first commit in the repository.
+Then it uses the first line of the output that matches the `stable-*` regular expression,
+or if no match was found, the first commit in the repository.
 
 ### Release
 

--- a/readme.md
+++ b/readme.md
@@ -137,7 +137,7 @@ name and email.
 To install the `poly` command on Linux:
 
 - Download the [latest release](https://github.com/polyfy/polylith/releases/latest) of the `poly` jar,
-  e.g. `poly-0.1.0-alpha8.jar`.
+  e.g. `poly-0.1.0-alpha9.jar`.
 - Create a directory, e.g. `/usr/local/polylith` and copy the jar file to that directory.
 - Create a file with the name `poly` and put it in e.g. `/usr/local/bin` with this content:
  ```
@@ -149,7 +149,7 @@ while [ "$1" != "" ] ; do
   shift
 done
 
-exec "/usr/bin/java" "-jar" "/usr/local/polylith/poly-0.1.0-alpha8.jar" $ARGS
+exec "/usr/bin/java" "-jar" "/usr/local/polylith/poly-0.1.0-alpha9.jar" $ARGS
 ```
 - Make sure that:
   - you point to the correct jar file.
@@ -193,13 +193,13 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 To install the `poly` command on Windows:
 
 - Download the [latest release](https://github.com/polyfy/polylith/releases/latest) of the `poly` jar,
-  e.g. `poly-0.1.0-alpha8.jar`.
+  e.g. `poly-0.1.0-alpha9.jar`.
 - Create the `Polylith` directory somewhere on your machine, e.g. 
   `C:\Program Files\Polylith` and copy the jar file to that directory.
 - Create the file `poly.bat` with this content (make sure you point to the jar):
 ```sh
 @echo off
-start /wait /b java -jar "C:\Program Files\Polylith\poly-0.1.0-alpha8.jar" %*
+start /wait /b java -jar "C:\Program Files\Polylith\poly-0.1.0-alpha9.jar" %*
 ```
 - Add `C:\Program Files\Polylith` to the Windows `PATH` variable.
 
@@ -218,7 +218,7 @@ To use it this way, add one of the following aliases to the `:aliases` section i
 {
 ...
  :aliases   {:poly  {:extra-deps {polylith/clj-poly
-                                  {:mvn/version "0.1.0-alpha8"}}
+                                  {:mvn/version "0.1.0-alpha9"}}
                      :main-opts  ["-m" "polylith.clj.core.poly-cli.core"]}}
 ...
 }
@@ -250,7 +250,7 @@ clj -M:poly info
 Similarly, you can use other artifacts from this repository, `clj-api` or `clj-poly-migrator` as dependencies. For example, in order to add `clj-api` as a dependency, add one of the following to your `:deps` section in your `deps.edn` file:
 
 ```clojure
-polylith/clj-api {:mvn/version "0.1.0-alpha8"}
+polylith/clj-api {:mvn/version "0.1.0-alpha9"}
 ```
 or
 ```clojure
@@ -2429,7 +2429,7 @@ poly ws get:settings
  :user-config-file "/Users/tengstrand/.polylith/config.edn",
  :user-home "/Users/tengstrand",
  :vcs "git",
- :version "0.1.0-alpha8",
+ :version "0.1.0-alpha9",
  :ws-schema-version {:breaking 0, :non-breaking 0}}
 ```
 


### PR DESCRIPTION
Retrieve tags based on git logs instead of git tags, when finding the latest stable or release tag.