### PR TITLE
Remove issue with clj-kondo by adding dummy-test

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/example/example" vcs="Git" />
   </component>
 </project>

--- a/components/creator/src/polylith/clj/core/creator/brick.clj
+++ b/components/creator/src/polylith/clj/core/creator/brick.clj
@@ -29,5 +29,8 @@
         ns-file (str bricks-dir "/test/" top-dir (common/ns-to-path interface-name) "/" namespace "_test.clj")]
     (file/create-missing-dirs ns-file)
     (file/create-file ns-file [(str "(ns " top-namespace "." interface-name "." namespace "-test")
-                               (str "  (:require [clojure.test :refer :all]))")])
+                               (str "  (:require [clojure.test :refer :all]))")
+                               ""
+                               (str "(defn dummy-test")
+                               (str "  (is (= 1 1)))")])
     (git/add ws-dir ns-file)))

--- a/components/creator/src/polylith/clj/core/creator/brick.clj
+++ b/components/creator/src/polylith/clj/core/creator/brick.clj
@@ -31,6 +31,6 @@
     (file/create-file ns-file [(str "(ns " top-namespace "." interface-name "." namespace "-test")
                                (str "  (:require [clojure.test :refer :all]))")
                                ""
-                               (str "(defn dummy-test")
+                               (str "(deftest dummy-test")
                                (str "  (is (= 1 1)))")])
     (git/add ws-dir ns-file)))

--- a/components/creator/test/polylith/clj/core/creator/base_test.clj
+++ b/components/creator/test/polylith/clj/core/creator/base_test.clj
@@ -59,6 +59,6 @@
     (is (= ["(ns se.example.my-base.core-test"
             "  (:require [clojure.test :refer :all]))"
             ""
-            "(defn dummy-test"
+            "(deftest dummy-test"
             "  (is (= 1 1)))"]
            (helper/content test-api-dir "core_test.clj")))))

--- a/components/creator/test/polylith/clj/core/creator/base_test.clj
+++ b/components/creator/test/polylith/clj/core/creator/base_test.clj
@@ -57,5 +57,8 @@
            (helper/content src-api-dir "core.clj")))
 
     (is (= ["(ns se.example.my-base.core-test"
-            "  (:require [clojure.test :refer :all]))"]
+            "  (:require [clojure.test :refer :all]))"
+            ""
+            "(defn dummy-test"
+            "  (is (= 1 1)))"]
            (helper/content test-api-dir "core_test.clj")))))

--- a/components/creator/test/polylith/clj/core/creator/component_test.clj
+++ b/components/creator/test/polylith/clj/core/creator/component_test.clj
@@ -57,7 +57,10 @@
            (helper/content src-ifc-dir "interface.clj")))
 
     (is (= ["(ns se.example.my-component.interface-test"
-            "  (:require [clojure.test :refer :all]))"]
+            "  (:require [clojure.test :refer :all]))"
+            ""
+            "(defn dummy-test"
+            "  (is (= 1 1)))"]
            (helper/content test-ifc-dir "interface_test.clj")))))
 
 (deftest create-component--without-with-a-different-interface--performs-expected-actions
@@ -103,5 +106,8 @@
            (helper/content src-ifc-dir "interface.clj")))
 
     (is (= ["(ns se.example.my-interface.interface-test"
-            "  (:require [clojure.test :refer :all]))"]
+            "  (:require [clojure.test :refer :all]))"
+            ""
+            "(defn dummy-test"
+            "  (is (= 1 1)))"]
            (helper/content test-ifc-dir "interface_test.clj")))))

--- a/components/creator/test/polylith/clj/core/creator/component_test.clj
+++ b/components/creator/test/polylith/clj/core/creator/component_test.clj
@@ -59,7 +59,7 @@
     (is (= ["(ns se.example.my-component.interface-test"
             "  (:require [clojure.test :refer :all]))"
             ""
-            "(defn dummy-test"
+            "(deftest dummy-test"
             "  (is (= 1 1)))"]
            (helper/content test-ifc-dir "interface_test.clj")))))
 
@@ -108,6 +108,6 @@
     (is (= ["(ns se.example.my-interface.interface-test"
             "  (:require [clojure.test :refer :all]))"
             ""
-            "(defn dummy-test"
+            "(deftest dummy-test"
             "  (is (= 1 1)))"]
            (helper/content test-ifc-dir "interface_test.clj")))))


### PR DESCRIPTION
The [issue 68](https://github.com/polyfy/polylith/issues/68) suggests that we remove the :require statement from the generated test namespace.
Instead we now add a dummy test, to get rid of the clj-kondo problem, and instead keep the :require statement, to make it easier for the user to start writing tests.
