### PR TITLE
keep dependencies exclusions in test runner

### DIFF
--- a/components/test-runner/src/polylith/clj/core/test_runner/core.clj
+++ b/components/test-runner/src/polylith/clj/core/test_runner/core.clj
@@ -8,9 +8,9 @@
             [polylith.clj.core.validator.interface :as validator])
   (:refer-clojure :exclude [test]))
 
-(defn adjust-key [{:keys [type path version]}]
+(defn adjust-key [{:keys [type path version exclusions]}]
   (case type
-    "maven" {:mvn/version version}
+    "maven" {:mvn/version version :exclusions (vec exclusions)}
     "local" {:local/root path}
     (throw (Exception. (str "Unknown library type: " type)))))
 


### PR DESCRIPTION
Hello,
In the test runner dependencies exclusions are lost when converting back to tools.deps format the project read from disk.
The aim of this fix is to make sure that they are kept.
Thanks