### PR TITLE
Expose interface file paths when reading the workspace

### DIFF
--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/components_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/components_from_disk.clj
@@ -13,14 +13,16 @@
         src-dir (str component-src-dir interface-path-name)
         namespaces-src (ns-from-disk/namespaces-from-disk component-src-dir)
         namespaces-test (ns-from-disk/namespaces-from-disk component-test-dir)
-        definitions (defs-from-disk/defs-from-disk src-dir interface-ns)]
+        definitions (defs-from-disk/defs-from-disk src-dir interface-ns)
+        interface-paths (defs-from-disk/interface-paths src-dir interface-ns :include-root? true)]
     (util/ordered-map :name component-name
                       :type "component"
                       :namespaces-src namespaces-src
                       :namespaces-test namespaces-test
                       :non-top-namespaces (brick->non-top-namespaces component-name)
                       :interface {:name interface-name
-                                  :definitions definitions})))
+                                  :definitions definitions
+                                  :paths (vec interface-paths)})))
 
 (defn read-components [ws-dir top-src-dir component-names interface-ns brick->non-top-namespaces]
   (vec (sort-by :name (map #(read-component ws-dir top-src-dir % interface-ns brick->non-top-namespaces) component-names))))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface_defs_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface_defs_from_disk.clj
@@ -20,10 +20,15 @@
     {:sub-ns namespace
      :path (str root-dir "/" path)}))
 
-(defn interface-namespaces [src-dir interface-ns]
+(defn interface-paths [src-dir interface-ns & {:keys [include-root?]}]
   (let [paths (filterv #(interface-ns? % interface-ns)
                        (map #(interface-path src-dir %)
                             (file/paths-recursively src-dir)))]
+    (cond->> paths
+      include-root? (map #(str src-dir "/" %)))))
+
+(defn interface-namespaces [src-dir interface-ns]
+  (let [paths (interface-paths src-dir interface-ns)]
     (mapv #(->interface-ns src-dir %) paths)))
 
 (defn interface-from-disk [{:keys [sub-ns path]} interface-ns]

--- a/components/workspace/src/polylith/clj/core/workspace/interfaces.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/interfaces.clj
@@ -4,7 +4,8 @@
   {:name (:name interface)
    :type "interface"
    :definitions (:definitions interface)
-   :implementing-components [name]})
+   :implementing-components [name]
+   :paths (:paths interface)})
 
 (defn params [parameters]
   (mapv :name parameters))
@@ -14,7 +15,8 @@
    :type "interface"
    :definitions (vec (sort-by (juxt :sub-ns :type :name params)
                               (set (mapcat #(-> % :interface :definitions) components))))
-   :implementing-components (vec (sort (map :name components)))})
+   :implementing-components (vec (sort (map :name components)))
+   :paths (mapcat #(-> % :interface :paths) components)})
 
 (defn calculate [components]
   "Calculates all interfaces, which are all definitions (data/function/macro)


### PR DESCRIPTION
### What?
Expose paths to interface files as part of the workspace.

`polylith.clj.core.workspace-clj.interface/workspace-from-disk` return data will now include a `:paths` field in the component interface data.

```clojure
{:components 
 [{:interface 
   {:paths ["/full/path/to/interface.clj"]}}]}
```

`polylith.clj.core.workspace.interface/enrich-workspace` will add the same `:paths` field to the interface data

```clojure
{:interfaces
 [{:path ["/full/path/to/interface.clj"]}]}
```

### Why?
It will be handy to be able to generate documentation for the interfaces of a given workspace. I looked into adding metadata, doc-strings and attr-map as part of the interface definitions. 

However due to the way poly tool currently reads files (using `clojure.core/read`) any metadata literals (`^{}`) defined does not get read and is not available for export. There are ways around this, but I doubt that it makes sense going through the effort to change how poly reads files.

Instead, if the paths to interfaces files are available on workspace level, anyone can use these paths as they see fit and integration with existing documentation tools become easier. 

The code change footprint is also much smaller

Finally the workspace file is less bloated than it would be if metadata is added (or alternatively if extra code has to be written to toggle metadata on and off).