### PR TITLE
Handle imports that aren't seqs

### DIFF
--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -5,11 +5,6 @@
             [polylith.clj.core.util.interface.str :as str-util])
   (:refer-clojure :exclude [import require]))
 
-(defn import? [statement]
-  (and
-    (sequential? statement)
-    (contains? #{:import :require} (first statement))))
-
 ;; (:require ,,,) handling
 
 (defn libspec?
@@ -47,6 +42,13 @@
     (-> import-list
         first
         str)))
+
+;; import/require handling
+
+(defn import? [statement]
+  (and
+    (sequential? statement)
+    (contains? #{:import :require} (first statement))))
 
 (defn import [[statement-type & statement-body]]
   (cond

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -11,7 +11,7 @@
     (contains? #{:import :require} (first statement))))
 
 (defn import [statement]
-  (map #(if (seq? %)
+  (map #(if (seqable? %)
           (-> % first str)
           %)
        (rest statement)))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -7,6 +7,7 @@
 
 ;; (:require ,,,) handling
 
+;; Borrowed from `clojure.core`, where it's a private fn.
 (defn libspec?
   "Returns true if x is a libspec."
   [x]
@@ -17,12 +18,14 @@
             (keyword? (second x))))))
 
 (defn libspec->lib
+  "Given a valid libspec, return the lib it's specifying."
   [libspec]
   (if (symbol? libspec)
     libspec
     (first libspec)))
 
-(defn prefix-list->libs
+(defn prefix-list->lib-strs
+  "Given a valid prefix list, return the libs they specify as strings."
   [[prefix & libspecs]]
   (map #(str prefix \.
              (libspec->lib %))
@@ -56,7 +59,7 @@
     (flatten
      (concat (map (comp str libspec->lib)
                   (filter libspec? statement-body))
-             (map prefix-list->libs
+             (map prefix-list->lib-strs
                   (remove libspec? statement-body))))
 
     (= :import statement-type)

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -33,6 +33,21 @@
              (libspec->lib %))
        libspecs))
 
+;; (:import ,,,) handling
+
+(defn import-list->package-str
+  "Given an import-list, as handled by `clojure.core/import`, return the
+  package name as a string."
+  [import-list]
+  (if (symbol? import-list)
+    (->> import-list
+         str
+         (re-find #"(.*)\.\w+$")
+         last)
+    (-> import-list
+        first
+        str)))
+
 (defn import [[statement-type & statement-body]]
   (cond
     (= :require statement-type)
@@ -43,10 +58,7 @@
                   (remove libspec? statement-body))))
 
     (= :import statement-type)
-    (map #(->> %
-               str
-               (re-find #"(.*)\.\w+$")
-               last)
+    (map import-list->package-str
          statement-body)))
 
 (defn imports [ns-statements]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -11,7 +11,10 @@
     (contains? #{:import :require} (first statement))))
 
 (defn import [statement]
-  (map #(-> % first str) (rest statement)))
+  (map #(if (seq? %)
+          (-> % first str)
+          %)
+       (rest statement)))
 
 (defn imports [ns-statements]
   (vec (sort (mapcat import (filterv import? ns-statements)))))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -10,11 +10,21 @@
     (sequential? statement)
     (contains? #{:import :require} (first statement))))
 
-(defn import [statement]
-  (map #(if (seqable? %)
+(defn import [[statement-type & statement-body]]
+  (map #(cond
+          ;; TODO make `sequential?`
+          (seqable? %)
           (-> % first str)
-          %)
-       (rest statement)))
+
+          (= :require statement-type)
+          (str %)
+
+          (= :import statement-type)
+          (->> %
+               str
+               (re-find #"(.*)\.\w+$")
+               last))
+       statement-body))
 
 (defn imports [ns-statements]
   (vec (sort (mapcat import (filterv import? ns-statements)))))

--- a/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
+++ b/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
@@ -22,3 +22,9 @@
     (is (= ["clojure.test"
             "polylith.spec.core"]
            (from-disk/imports code)))))
+
+(deftest imports--bare-import--returns-imported-namespaces
+  (let [code '(ns polylith.clj.core.file.core
+                (:import java.io.File))]
+    (is (= ["java.io"]
+           (from-disk/imports code)))))

--- a/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
+++ b/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
@@ -23,11 +23,13 @@
             "polylith.spec.core"]
            (from-disk/imports code)))))
 
-(deftest imports--bare-import--returns-imported-namespaces
+(deftest imports--all-import-forms--returns-imported-packages
   (let [code '(ns polylith.clj.core.file.core
-                (:import java.io.File))]
-    (is (= ["java.io"]
-           (from-disk/imports code)))))
+                (:import java.io.File
+                         (java.nio.file Files)))]
+    (testing "only package names are returned"
+      (is (= ["java.io" "java.nio.file"]
+             (from-disk/imports code))))))
 
 (deftest imports--all-require-forms--return-imported-namespaces
   (let [code '(ns polylith.clj.core.file.core

--- a/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
+++ b/components/workspace-clj/test/polylith/clj/core/workspace_clj/readimportsfromdisk_test.clj
@@ -28,3 +28,13 @@
                 (:import java.io.File))]
     (is (= ["java.io"]
            (from-disk/imports code)))))
+
+(deftest imports--all-require-forms--return-imported-namespaces
+  (let [code '(ns polylith.clj.core.file.core
+                (:require lib.a
+                          [lib.b]
+                          [lib.c :as c]
+                          [foo bar [baz :as baz]]))
+        result (from-disk/imports code)]
+    (is (= ["foo.bar" "foo.baz" "lib.a" "lib.b" "lib.c"]
+           result))))


### PR DESCRIPTION
The current implementation assumes that each of the items in your
`:require` and `:import` forms are seqable, but that may not be the case,
at which point the poly_cli will throw an exception and quit.

This commit works around that by checking explicitly for whether the
import is seqable, and doing the right thing for each case.

As I'm writing some new tests, I've realized that my initial patch doesn't 
/quite/ work, because the expectation with imports, currently, is that
something like `[java.io File]` turns into `"java.io"`, so a naive call to `str`
doesn't return the same results.

This doesn't apply to a `:require` form, however, so that requires a bit
more finesse.

I'll work on a solution and push the changes.

See #73 for more details.