### PR TITLE
Clarify development directory description

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -298,7 +298,7 @@ Each top-level directory contains a specific type of Polylith concept.
 A `base` is a building block that exposes a public API to external systems. 
 A `component` is a building block for encapsulating a specific domain or part of the system.
 A `project` specifies our deployable artifacts and what components, bases, and libraries they contain. 
-Finally, we have the `development` project (`development` + `deps.edn`) 
+Finally, we have the `development` directory (+ `deps.edn`) 
 that we use to work with the code in one place.
 
 This structure gives a consistent shape to all Polylith projects, and ensures that both new developers 


### PR DESCRIPTION
Hi! I just want to first say thank you for the time you've put sharing this tool and the Polylith architecture. The gitbook is very polished and concise, and this readme looks very thorough. I've read through the docs and watched some videos and am now trying out the walkthrough in this readme.

In the part describing the directories created by the tool, "development project" seemed a bit confusing to me at first glance, and I looked into the project directory just to make sure there wasn't some "project" called development as well. I'm not sure if this change makes sense to you, but if so maybe it can be merged.