### PR TITLE
Use depstar for deployer

### DIFF
--- a/components/deployer/src/polylith/clj/core/deployer/core.clj
+++ b/components/deployer/src/polylith/clj/core/deployer/core.clj
@@ -28,18 +28,15 @@
                        :project-name project-name
                        :type         type}
                       e))))
-  (println (str (name type) " is built.")))
+  (println (str (str/capitalize (name type)) " is built.")))
 
 (defn deploy-project [current-dir project-name]
   (create-pom-xml current-dir project-name)
   (try
-    (let [project-prefix (str (file/current-dir) "/projects/" project-name)
-          coordinates (:coordinates (deps-deploy/coordinates-from-pom (slurp (str (file/current-dir) "/projects/" project-name "/pom.xml"))))
-          artifact-map {[:extension "pom" :classifier nil] (str project-prefix "/pom.xml")
-                        [:extension "jar" :classifier nil] (str project-prefix "/target/" project-name "-thin.jar")}]
-      (deps-deploy/deploy {:installer    :clojars
-                           :coordinates  coordinates
-                           :artifact-map artifact-map}))
+    (let [project-prefix (str (file/current-dir) "/projects/" project-name)]
+      (deps-deploy/deploy {:artifact (str project-prefix "/target/" project-name "-thin.jar")
+                           :pom-file (str project-prefix "/pom.xml")
+                           :installer    :remote}))
     (catch Exception e
       (throw (ex-info (str "Could not deploy " project-name " project to clojars.")
                       {:current-dir current-dir

--- a/components/deployer/src/polylith/clj/core/deployer/core.clj
+++ b/components/deployer/src/polylith/clj/core/deployer/core.clj
@@ -21,7 +21,7 @@
 (defn build-jar [current-dir project-name type]
   (println (str "Building " (name type) "..."))
   (try
-    (shell/sh (if (= :uberjar type) "./build-uberjar.sh" "./build-skinny-jar.sh") project-name :dir (str current-dir "/scripts"))
+    (shell/sh (if (= :uberjar type) "./build-uberjar.sh" "./build-thin-jar.sh") project-name :dir (str current-dir "/scripts"))
     (catch Exception e
       (throw (ex-info (str "Unable to build a " (name type) " for " project-name " project.")
                       {:current-dir  current-dir
@@ -36,7 +36,7 @@
     (let [project-prefix (str (file/current-dir) "/projects/" project-name)
           coordinates (:coordinates (deps-deploy/coordinates-from-pom (slurp (str (file/current-dir) "/projects/" project-name "/pom.xml"))))
           artifact-map {[:extension "pom" :classifier nil] (str project-prefix "/pom.xml")
-                        [:extension "jar" :classifier nil] (str project-prefix "/target/" project-name "-skinny.jar")}]
+                        [:extension "jar" :classifier nil] (str project-prefix "/target/" project-name "-thin.jar")}]
       (deps-deploy/deploy {:installer    :clojars
                            :coordinates  coordinates
                            :artifact-map artifact-map}))
@@ -56,7 +56,7 @@
       (throw (Exception. "Cannot deploy projects. None of the projects in this workspace changed.")))
     (doseq [project-name changed-projects]
       (println (str "Starting deployment for " project-name " project."))
-      (build-jar current-dir project-name :skinny-jar)
+      (build-jar current-dir project-name :jar)
       (deploy-project current-dir project-name)
       (println (str "Deployment completed for " project-name " project.")))))
 

--- a/projects/api/deps.edn
+++ b/projects/api/deps.edn
@@ -19,6 +19,7 @@
 
         org.clojure/clojure {:mvn/version "1.10.3"}}
 
- :aliases {:skinny-jar {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
-                                                      :sha "0e8731e0f24db05b74769e219051b0e92b50624a"}}
-                        :main-opts ["-m" "mach.pack.alpha.skinny" "--no-libs" "--project-path" "target/api-skinny.jar"]}}}
+ :aliases {:jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.250"}}
+                 :exec-fn hf.depstar/jar
+                 :exec-args {:jar "api-thin.jar"
+                             :target-dir "target"}}}}

--- a/projects/api/partial_pom.xml
+++ b/projects/api/partial_pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.3</version>
     </dependency>
     <dependency>
       <groupId>mvxcvi</groupId>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>malli</artifactId>
-      <version>0.1.0</version>
+      <version>0.5.1</version>
     </dependency>
     <dependency>
       <groupId>me.raynes</groupId>

--- a/projects/poly/deps.edn
+++ b/projects/poly/deps.edn
@@ -33,6 +33,7 @@
                      :exec-fn hf.depstar/uberjar
                      :exec-args {:aot true, :main-class polylith.clj.core.poly-cli.core}}
 
-           :skinny-jar {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
-                                                      :sha     "0e8731e0f24db05b74769e219051b0e92b50624a"}}
-                        :main-opts  ["-m" "mach.pack.alpha.skinny" "--no-libs" "--project-path" "target/poly-skinny.jar"]}}}
+           :jar {:replace-deps {com.github.seancorfield/depstar {:mvn/version "2.1.278"}}
+                 :exec-fn hf.depstar/jar
+                 :exec-args {:jar "poly-thin.jar"
+                             :target-dir "target"}}}}

--- a/projects/poly/partial_pom.xml
+++ b/projects/poly/partial_pom.xml
@@ -11,22 +11,18 @@
     <dependency>
       <groupId>org.clojure</groupId>
       <artifactId>clojure</artifactId>
-      <version>1.10.1</version>
+      <version>1.10.3</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.13.3</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.32</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>mvxcvi</groupId>
       <artifactId>puget</artifactId>
       <version>1.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>
@@ -36,12 +32,17 @@
     <dependency>
       <groupId>metosin</groupId>
       <artifactId>malli</artifactId>
-      <version>0.1.0</version>
+      <version>0.5.1</version>
     </dependency>
     <dependency>
       <groupId>me.raynes</groupId>
       <artifactId>fs</artifactId>
       <version>1.4.6</version>
+    </dependency>
+    <dependency>
+      <groupId>zprint</groupId>
+      <artifactId>zprint</artifactId>
+      <version>1.1.2</version>
     </dependency>
   </dependencies>
   <repositories>

--- a/scripts/build-thin-jar.sh
+++ b/scripts/build-thin-jar.sh
@@ -13,12 +13,12 @@ mkdir -p target
 
 rm -rf target/$1.*
 
-clojure -A:skinny-jar
+clojure -X:jar
 
 if [[ $? -ne 0 ]]
 then
-  echo "Could not create skinny jar for the project."
+  echo "Could not create thin jar for the project."
   exit 1
 fi
 
-echo "Skinny jar created."
+echo "Thin jar created."


### PR DESCRIPTION
- Use [seancorfield/depstar](https://github.com/seancorfield/depstar) instead of [pack/pack.alpha](https://github.com/juxt/pack.alpha) in the `deployer` component for deploying Polylith artifacts to [clojars](https://clojars.org).
- Fixed invalid usage of [slipset/deps-deploy](https://github.com/slipset/deps-deploy). The version of the library is incremented during the development of #94 but the way we use was not updated accordingly. Now that is fixed.