### PR TITLE
LSP cache moved; ignore clj-kondo cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ projects/**/pom.xml
 
 # clojure-lsp
 .lsp/sqlite*.db
+.lsp/.cache
+.clj-kondo/.cache
 
 # Calva
 .calva/output-window/output.calva-repl


### PR DESCRIPTION
Recent versions of LSP have migrated the `sqlite.db` file to `.lsp/.cache` so we should ignore both locations. LSP runs `clj-kondo` so we should ignore that cache too.