### PR TITLE
Make sure we don't crash if a source file is a symbolic link to a non-existing file.

### DIFF
--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -67,8 +67,11 @@
   (.getName file))
 
 (defn lines-of-code [file-path]
-  (with-open [rdr (io/reader file-path)]
-    (count (line-seq rdr))))
+  (try
+    (with-open [rdr (io/reader file-path)]
+      (count (line-seq rdr)))
+    (catch FileNotFoundException _
+      0)))
 
 (defn directory-paths [dir]
   (->> dir


### PR DESCRIPTION
See issue #138.