### PR TITLE
Use correct path to maven repository when running tests

### DIFF
--- a/components/deps/src/polylith/clj/core/deps/lib_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/lib_deps.clj
@@ -1,5 +1,6 @@
 (ns polylith.clj.core.deps.lib-deps
-  (:require [clojure.tools.deps.alpha :as tools-deps]))
+  (:require [clojure.tools.deps.alpha :as tools-deps]
+            [polylith.clj.core.user-config.interface :as user-config]))
 
 (defn name-version [[k {:keys [mvn/version]}]]
   [(str k) version])
@@ -41,10 +42,11 @@
    we merge :src and :test."
   [{:keys [lib-deps maven-repos]}
    {:keys [m2-dir]}]
-  {:mvn/repos maven-repos
-   :mvn/local-repo m2-dir
-   :deps (into {} (map key-as-symbol (merge (:src lib-deps)
-                                            (:test lib-deps))))})
+  (cond-> {:mvn/repos maven-repos
+           :deps (into {} (map key-as-symbol (merge (:src lib-deps)
+                                                    (:test lib-deps))))}
+          (-> m2-dir user-config/m2-home-dir? not) (assoc :mvn/local-repo (str m2-dir "/repository"))))
+
 (defn resolve-deps [project settings is-verbose]
   "Resolves which library versions that are used by the given project."
   (let [config (->config project settings)

--- a/components/user-config/src/polylith/clj/core/user_config/core.clj
+++ b/components/user-config/src/polylith/clj/core/user_config/core.clj
@@ -23,5 +23,8 @@
   (:m2-dir (config-content)
            (str (home-dir) "/.m2")))
 
+(defn m2-home-dir? [m2-dir]
+  (= m2-dir (str (home-dir) "/.m2")))
+
 (defn thousand-separator []
   (:thousand-separator (config-content) ","))

--- a/components/user-config/src/polylith/clj/core/user_config/interface.clj
+++ b/components/user-config/src/polylith/clj/core/user_config/interface.clj
@@ -13,5 +13,8 @@
 (defn m2-dir []
   (core/m2-dir))
 
+(defn m2-home-dir? [m2-dir]
+  (core/m2-home-dir? m2-dir))
+
 (defn thousand-separator []
   (core/thousand-separator))

--- a/projects/poly/test/project/poly/workspace_test.clj
+++ b/projects/poly/test/project/poly/workspace_test.clj
@@ -111,7 +111,7 @@
           "  command        .  x  .  x  x  x  x  x  x  x  x  .  .  x  x  .  x  .  x  .  x  x  x  x  x  x  x"
           "  common         .  .  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .  .  ."
           "  creator        .  .  .  x  .  .  x  x  .  .  .  .  .  .  .  t  .  .  .  .  x  .  .  .  .  .  ."
-          "  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  ."
+          "  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  x  .  .  .  .  .  ."
           "  file           .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  ."
           "  git            .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .  .  x  .  .  .  .  .  ."
           "  help           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  ."
@@ -158,7 +158,7 @@
             "  command        x  .  x  x  x  x  x  x  x  x  +  +  x  x  .  x  +  x  +  x  x  x  x  x  x  x"
             "  common         .  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .  .  ."
             "  creator        -  -  x  -  -  x  x  -  -  -  -  +  -  -  t  -  -  +  -  x  -  -  -  -  -  -"
-            "  deps           .  .  x  .  .  +  .  .  .  .  .  .  .  .  .  .  x  +  .  x  .  .  .  .  .  ."
+            "  deps           .  .  x  .  .  +  .  .  .  .  .  .  .  .  .  .  x  x  .  x  .  .  .  .  .  ."
             "  file           .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  ."
             "  git            .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .  .  x  .  .  .  .  .  ."
             "  help           .  .  x  .  .  +  .  .  .  .  .  .  .  .  .  .  .  +  .  x  .  x  .  .  .  ."
@@ -311,14 +311,14 @@
                                              "ws-file"]}}
           "deps"          {:src  {:direct   ["common"
                                              "text-table"
+                                             "user-config"
                                              "util"]
-                                  :indirect ["file"
-                                             "user-config"]}
+                                  :indirect ["file"]}
                            :test {:direct   ["common"
                                              "text-table"
+                                             "user-config"
                                              "util"]
-                                  :indirect ["file"
-                                             "user-config"]}}
+                                  :indirect ["file"]}}
           "file"          {:src  {:direct ["util"]}
                            :test {}}
           "git"           {:src  {:direct ["sh"


### PR DESCRIPTION
Add the configured m2-dir + `/repository` to the configuration (key `:mvn/local-repo`) when running tests, if it's configured as something else than `~/.m2` in `~/.polylith/config.edn`.