### PR TITLE
Handle :git/sha correctly in library dependencies

### DIFF
--- a/components/lib/src/polylith/clj/core/lib/git_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/git_size.clj
@@ -4,10 +4,8 @@
             [polylith.clj.core.util.interface :as util]))
 
 (defn dir-size [root-path sha]
-  (let [dir (str root-path "/" sha)]
-    (when (and sha
-               (file/exists dir))
-      (apply + (map file/size (file/paths-recursively dir))))))
+  (when sha
+    (file/size (str root-path "/" sha))))
 
 (defn sha-version [sha]
   (when sha
@@ -15,14 +13,18 @@
       (subs sha 0 7)
       sha)))
 
-(defn full-sha [sha root-path user-home]
-  (util/find-first #(str/starts-with? % sha)
-                   (:dirs (file/files-and-dirs root-path user-home))))
+(defn full-sha [sha path user-home]
+  (when sha
+    (util/find-first #(str/starts-with? % sha)
+                     (:dirs (file/files-and-dirs path user-home)))))
 
-(defn with-size-and-version [lib-name sha value user-home]
-  (let [root-path (str user-home "/.gitlibs/libs/" lib-name)
-        full-sha (full-sha sha root-path user-home)
-        version (sha-version sha)]
-    (if-let [size (dir-size root-path full-sha)]
-      [lib-name (assoc value :type "git" :size size :version version)]
-      [lib-name (assoc value :type "git" :version version)])))
+(defn root-path [user-home lib-name]
+  (str user-home "/.gitlibs/libs/" lib-name))
+
+(defn with-size-and-version [lib-name sha coords user-home]
+  (let [path (root-path user-home lib-name)
+        full-sha (full-sha sha path user-home)
+        version (sha-version sha)
+        size (dir-size path full-sha)]
+    [lib-name (cond-> (assoc coords :type "git" :version version)
+                      size (assoc :size size))]))

--- a/components/lib/src/polylith/clj/core/lib/local_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/local_size.clj
@@ -8,11 +8,11 @@
     (when (file/exists absolute-path)
       (file/size absolute-path))))
 
-(defn with-size-and-version [ws-dir lib-name path value entity-root-path]
+(defn with-size-and-version [ws-dir lib-name path coords entity-root-path]
   (let [size (file-size ws-dir path entity-root-path)
         version (version/version path)
         absolute-path (common/absolute-path path entity-root-path)]
-    [lib-name (cond-> (assoc value :type "local")
+    [lib-name (cond-> (assoc coords :type "local")
                       absolute-path (assoc :path absolute-path)
                       size (assoc :size size)
                       version (assoc :version version))]))

--- a/components/lib/src/polylith/clj/core/lib/mvn_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/mvn_size.clj
@@ -21,7 +21,7 @@
 (defn with-maven [value]
   (assoc (walk/postwalk-replace {:mvn/version :version} value) :type "maven"))
 
-(defn with-size [lib-name version value]
+(defn with-size [lib-name version coords]
   (if-let [size (lib-size-bytes lib-name version)]
-    [lib-name (assoc (with-maven value) :size size)]
-    [lib-name (with-maven value)]))
+    [lib-name (assoc (with-maven coords) :size size)]
+    [lib-name (with-maven coords)]))

--- a/components/lib/src/polylith/clj/core/lib/size.clj
+++ b/components/lib/src/polylith/clj/core/lib/size.clj
@@ -3,13 +3,17 @@
             [polylith.clj.core.lib.mvn-size :as mvn-size]
             [polylith.clj.core.lib.local-size :as local-size]))
 
-(defn with-size [ws-dir [name {:keys [mvn/version local/root git/url git/tag sha] :as value}] entity-root-path user-home]
-  (let [git-sha (:git/sha value)
+(defn destruct [{sha1 :sha :keys [git/sha local/root mvn/version]}]
+  {:sha (or sha sha1)
+   :root root
+   :version version})
+
+(defn with-size [ws-dir [name coords] entity-root-path user-home]
+  (let [{:keys [sha version root]} (destruct coords)
         [lib-name lib] (cond
-                         version (mvn-size/with-size name version value)
-                         root (local-size/with-size-and-version ws-dir name root value entity-root-path)
-                         url (git-size/with-size-and-version name sha value user-home)
-                         tag (git-size/with-size-and-version name git-sha value user-home))]
+                         version (mvn-size/with-size name version coords)
+                         root (local-size/with-size-and-version ws-dir name root coords entity-root-path)
+                         :else (git-size/with-size-and-version name sha coords user-home))]
     [(str lib-name) lib]))
 
 (defn with-sizes-vec [ws-dir entity-root-path libraries user-home]

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -4,10 +4,10 @@
 (def major 0)
 (def minor 2)
 (def patch 14)
-(def revision "alpha-issue146-03")
+(def revision "alpha-issue174-01")
 (def name (str major "." minor "." patch "-" revision))
 
-(def date "2022-01-04")
+(def date "2022-01-17")
 
 (defn version
   ([ws-type]

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -29,7 +29,7 @@ poly help
 ```
 
 ```
-  Poly 0.2.13-alpha-03 (2021-10-10) - https://github.com/polyfy/polylith
+  Poly 0.2.14-alpha-issue174-01 (2022-01-17) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/examples/doc-example/ws.edn
+++ b/examples/doc-example/ws.edn
@@ -7,13 +7,13 @@
     [{:name "core",
       :namespace "se.example.cli.core",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/bases/cli/src/se/example/cli/core.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/bases/cli/src/se/example/cli/core.clj",
       :imports ["se.example.user.interface"]}],
     :test
     [{:name "core-test",
       :namespace "se.example.cli.core-test",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/bases/cli/test/se/example/cli/core_test.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/bases/cli/test/se/example/cli/core_test.clj",
       :imports ["clojure.test" "se.example.cli.core"]}]},
    :lib-deps {},
    :lines-of-code {:src 7, :test 6},
@@ -27,18 +27,18 @@
     [{:name "core",
       :namespace "se.example.user-api.core",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/bases/user-api/src/se/example/user_api/core.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/bases/user-api/src/se/example/user_api/core.clj",
       :imports ["se.example.user-api.api" "slacker.server"]}
      {:name "api",
       :namespace "se.example.user-api.api",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/bases/user-api/src/se/example/user_api/api.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/bases/user-api/src/se/example/user_api/api.clj",
       :imports ["se.example.user.interface"]}],
     :test
     [{:name "core-test",
       :namespace "se.example.user-api.core-test",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/bases/user-api/test/se/example/user_api/core_test.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/bases/user-api/test/se/example/user_api/core_test.clj",
       :imports ["clojure.test" "se.example.user-api.core"]}]},
    :lib-deps
    {:src
@@ -51,7 +51,7 @@
    :interface-deps {:src ["user"], :test []}}],
  :changes
  {:since "stable",
-  :since-sha "488d9ead6d5963316c51fa3aa694ce9cfeea530d",
+  :since-sha "0fcfcf98b023183fe263861e53fb0beb228104ef",
   :since-tag "stable-lisa",
   :changed-files
   ["bases/user-api/deps.edn"
@@ -67,7 +67,7 @@
    "projects/user-service/deps.edn"
    "workspace.edn"],
   :git-diff-command
-  "git diff 488d9ead6d5963316c51fa3aa694ce9cfeea530d --name-only",
+  "git diff 0fcfcf98b023183fe263861e53fb0beb228104ef --name-only",
   :changed-components ["user-remote"],
   :changed-bases ["user-api"],
   :changed-projects ["command-line" "user-service"],
@@ -94,18 +94,18 @@
     [{:name "interface",
       :namespace "se.example.user.interface",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user/src/se/example/user/interface.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user/src/se/example/user/interface.clj",
       :imports ["se.example.user.core"]}
      {:name "core",
       :namespace "se.example.user.core",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user/src/se/example/user/core.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user/src/se/example/user/core.clj",
       :imports []}],
     :test
     [{:name "interface-test",
       :namespace "se.example.user.interface-test",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user/test/se/example/user/interface_test.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user/test/se/example/user/interface_test.clj",
       :imports ["clojure.test" "se.example.user.interface"]}]},
    :lib-imports {:test ["clojure.test"]},
    :name "user",
@@ -123,18 +123,18 @@
     [{:name "interface",
       :namespace "se.example.user.interface",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user-remote/src/se/example/user/interface.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user-remote/src/se/example/user/interface.clj",
       :imports ["se.example.user.core"]}
      {:name "core",
       :namespace "se.example.user.core",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user-remote/src/se/example/user/core.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user-remote/src/se/example/user/core.clj",
       :imports ["slacker.client"]}],
     :test
     [{:name "interface-test",
       :namespace "se.example.user.interface-test",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/components/user-remote/test/se/example/user/interface_test.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/components/user-remote/test/se/example/user/interface_test.clj",
       :imports ["clojure.test" "se.example.user.interface"]}]},
    :lib-imports {:src ["slacker.client"], :test ["clojure.test"]},
    :name "user-remote",
@@ -196,12 +196,12 @@
     [{:name "project.command-line.test-setup",
       :namespace "project.command-line.test-setup",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/command-line/test/project/command_line/test_setup.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/command-line/test/project/command_line/test_setup.clj",
       :imports ["clojure.test"]}
      {:name "project.command-line.dummy-test",
       :namespace "project.command-line.dummy_test",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/command-line/test/project/command_line/dummy_test.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/command-line/test/project/command_line/dummy_test.clj",
       :imports ["clojure.test"]}]},
    :base-names {:src ["cli"], :test ["cli"]},
    :lib-imports
@@ -226,7 +226,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "cl",
    :project-dir
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/command-line",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/command-line",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -245,7 +245,7 @@
      "slacker/slacker"
      {:version "0.17.0", :type "maven", :size 28408}}},
    :config-filename
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/command-line/deps.edn",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/command-line/deps.edn",
    :component-names {:src ["user-remote"], :test ["user-remote"]},
    :deps
    {"cli"
@@ -273,7 +273,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "user-s",
    :project-dir
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/user-service",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/user-service",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -287,7 +287,7 @@
      "slacker/slacker"
      {:version "0.17.0", :type "maven", :size 28408}}},
    :config-filename
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/projects/user-service/deps.edn",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/projects/user-service/deps.edn",
    :component-names {:src ["user"], :test ["user"]},
    :deps
    {"user-api"
@@ -299,7 +299,7 @@
     [{:name "dev.lisa",
       :namespace "dev.lisa",
       :file-path
-      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/development/src/dev/lisa.clj",
+      "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/development/src/dev/lisa.clj",
       :imports ["slacker.client"]}]},
    :base-names {:src ["cli" "user-api"], :test ["cli" "user-api"]},
    :lib-imports
@@ -329,7 +329,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "dev",
    :project-dir
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/development",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/development",
    :unmerged
    {:paths
     {:src
@@ -363,7 +363,7 @@
      "org.apache.logging.log4j/log4j-slf4j-impl"
      {:version "2.13.3", :type "maven", :size 23590}}},
    :config-filename
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example/deps.edn",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example/deps.edn",
    :component-names {:src ["user"], :test ["user"]},
    :deps
    {"cli"
@@ -376,11 +376,11 @@
   {:name "git",
    :branch "main",
    :git-root
-   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example",
+   "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example",
    :auto-add true,
    :stable-since
    {:tag "stable-lisa",
-    :sha "488d9ead6d5963316c51fa3aa694ce9cfeea530d"},
+    :sha "0fcfcf98b023183fe263861e53fb0beb228104ef"},
    :polylith
    {:repo "https://github.com/polyfy/polylith.git", :branch "master"}},
   :top-namespace "se.example",
@@ -396,8 +396,8 @@
   :profile-to-settings
   {"default"
    {:paths
-    ["components/user/src"
-     "components/user/resources"
+    ["components/user/resources"
+     "components/user/src"
      "components/user/test"],
     :lib-deps {},
     :component-names ["user"],
@@ -405,8 +405,8 @@
     :project-names []},
    "remote"
    {:paths
-    ["components/user-remote/src"
-     "components/user-remote/resources"
+    ["components/user-remote/resources"
+     "components/user-remote/src"
      "components/user-remote/test"],
     :lib-deps {},
     :component-names ["user-remote"],
@@ -447,15 +447,15 @@
   :unnamed-args []},
  :version
  {:release
-  {:name "0.2.13-alpha-03",
+  {:name "0.2.14-alpha-issue174-01",
    :major 0,
    :minor 2,
-   :patch 13,
-   :revision "alpha-03",
-   :date "2021-10-10"},
+   :patch 14,
+   :revision "alpha-issue174-01",
+   :date "2022-01-17"},
   :ws {:type :toolsdeps2, :breaking 1, :non-breaking 0}},
  :ws-dir
- "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2021-10-12-203528.MWwVMIRb/example",
+ "/private/var/folders/q7/ky18vssj6jz0mhfr8lcv1xzh0000gp/T/polylith-ws-2022-01-17-205011.4Gkk80AK/example",
  :ws-reader
  {:name "polylith-clj",
   :project-url "https://github.com/polyfy/polylith",

--- a/projects/poly/test/project/poly/workspace_test.clj
+++ b/projects/poly/test/project/poly/workspace_test.clj
@@ -77,7 +77,7 @@
           "  library                           version        type      KB   api  poly   dev   s  e  r  l  p  r  j  r"
           "  -------------------------------------------------------------   ---------   ---   ----------------------"
           "  djblue/portal                     0.18.1         maven    768    -    x      x    .  .  .  .  x  .  .  ."
-          "  io.github.seancorfield/build-clj  6e962ef        git       78    -    -      x    .  .  .  .  .  .  .  ."
+          "  io.github.seancorfield/build-clj  6e962ef        git       39    -    -      x    .  .  .  .  .  .  .  ."
           "  me.raynes/fs                      1.4.6          maven     10    x    x      x    .  x  .  .  .  .  .  ."
           "  metosin/malli                     0.7.1          maven     54    x    x      x    .  .  .  .  .  x  .  ."
           "  mount/mount                       0.1.16         maven      8    -    -      x    .  .  .  .  .  .  .  ."

--- a/scripts/output/help/01-help.txt
+++ b/scripts/output/help/01-help.txt
@@ -1,4 +1,4 @@
-  Poly 0.2.13-alpha-03 (2021-10-10) - https://github.com/polyfy/polylith
+  Poly 0.2.14-alpha-issue174-01 (2022-01-17) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/scripts/output/local-dep-old-format/libs-migrated.txt
+++ b/scripts/output/local-dep-old-format/libs-migrated.txt
@@ -3,7 +3,7 @@
                                                                      i
   library                       version   type      KB   inv   dev   l
   ----------------------------------------------------   ---   ---   -
-  clj-time/clj-time             d9ed4e4   git      354    x     x    x
+  clj-time/clj-time             d9ed4e4   git      133    x     x    x
   migrate-me/migrate-me         -         local      0    t     t    .
   org.clojure/clojure           1.10.1    maven  3,816    x     x    .
   org.clojure/tools.deps.alpha  0.12.985  maven     59    x     x    .

--- a/scripts/output/local-dep-old-format/libs.txt
+++ b/scripts/output/local-dep-old-format/libs.txt
@@ -3,7 +3,7 @@
                                                                      i
   library                       version   type      KB   inv   dev   l
   ----------------------------------------------------   ---   ---   -
-  clj-time/clj-time             d9ed4e4   git      354    x     x    x
+  clj-time/clj-time             d9ed4e4   git      133    x     x    x
   migrate-me/migrate-me         -         local      0    t     t    .
   org.clojure/clojure           1.10.1    maven  3,816    x     x    .
   org.clojure/tools.deps.alpha  0.12.985  maven     59    x     x    .

--- a/scripts/output/local-dep-old-format/ws.edn
+++ b/scripts/output/local-dep-old-format/ws.edn
@@ -188,8 +188,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"}}}}
+      :version "d9ed4e4",
+      :size 136427}}}}
   {:lines-of-code {:src 0, :test 5},
    :interface {:definitions []},
    :namespaces
@@ -327,8 +327,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"}},
+      :version "d9ed4e4",
+      :size 136427}},
     :test
     {"migrate-me/migrate-me"
      {:local/root "../../migrate-me",
@@ -439,8 +439,8 @@
       {:git/url "https://github.com/clj-time/clj-time.git",
        :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
        :type "git",
-       :size 362768,
-       :version "d9ed4e4"},
+       :version "d9ed4e4",
+       :size 136427},
       "uncomplicate/neanderthal"
       {:version "0.41.0",
        :exclusions [org.jcuda/jcuda-natives org.jcuda/jcublas-natives],
@@ -462,8 +462,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"},
+      :version "d9ed4e4",
+      :size 136427},
      "uncomplicate/neanderthal"
      {:version "0.41.0",
       :exclusions [org.jcuda/jcuda-natives org.jcuda/jcublas-natives],
@@ -563,12 +563,12 @@
   :is-no-exit false},
  :version
  {:release
-  {:name "0.2.13-alpha-03",
+  {:name "0.2.14-alpha-issue174-01",
    :major 0,
    :minor 2,
-   :patch 13,
-   :revision "alpha-03",
-   :date "2021-10-10"},
+   :patch 14,
+   :revision "alpha-issue174-01",
+   :date "2022-01-17"},
   :ws {:type :toolsdeps2, :breaking 1, :non-breaking 0},
   :from {:ws {:type :toolsdeps1}}},
  :ws-dir "/privateWS-HOME/local-dep-old-format",

--- a/scripts/output/local-dep/libs-compact.txt
+++ b/scripts/output/local-dep/libs-compact.txt
@@ -7,7 +7,7 @@
                                                                      e i
   library                       version   type      KB   inv   dev   r l
   ----------------------------------------------------   ---   ---   ---
-  clj-time/clj-time             d9ed4e4   git      354    x     x    . x
+  clj-time/clj-time             d9ed4e4   git      133    x     x    . x
   migrate-me/migrate-me         -         local      0    t     t    t .
   org.clojure/clojure           1.10.1    maven  3,816    x     x    . .
   org.clojure/tools.deps.alpha  0.12.985  maven     59    x     x    . .

--- a/scripts/output/local-dep/libs.txt
+++ b/scripts/output/local-dep/libs.txt
@@ -7,7 +7,7 @@
                                                                      e  i
   library                       version   type      KB   inv   dev   r  l
   ----------------------------------------------------   ---   ---   ----
-  clj-time/clj-time             d9ed4e4   git      354    x     x    .  x
+  clj-time/clj-time             d9ed4e4   git      133    x     x    .  x
   migrate-me/migrate-me         -         local      0    t     t    t  .
   org.clojure/clojure           1.10.1    maven  3,816    x     x    .  .
   org.clojure/tools.deps.alpha  0.12.985  maven     59    x     x    .  .

--- a/scripts/output/local-dep/ws.edn
+++ b/scripts/output/local-dep/ws.edn
@@ -203,8 +203,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"}}}}
+      :version "d9ed4e4",
+      :size 136427}}}}
   {:lines-of-code {:src 0, :test 5},
    :interface {:definitions []},
    :namespaces
@@ -342,8 +342,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"}},
+      :version "d9ed4e4",
+      :size 136427}},
     :test
     {"migrate-me/migrate-me"
      {:local/root "../../migrate-me",
@@ -457,8 +457,8 @@
       {:git/url "https://github.com/clj-time/clj-time.git",
        :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
        :type "git",
-       :size 362768,
-       :version "d9ed4e4"},
+       :version "d9ed4e4",
+       :size 136427},
       "uncomplicate/neanderthal"
       {:version "0.41.0",
        :exclusions [org.jcuda/jcuda-natives org.jcuda/jcublas-natives],
@@ -480,8 +480,8 @@
      {:git/url "https://github.com/clj-time/clj-time.git",
       :sha "d9ed4e46c6b42271af69daa1d07a6da2df455fab",
       :type "git",
-      :size 362768,
-      :version "d9ed4e4"},
+      :version "d9ed4e4",
+      :size 136427},
      "uncomplicate/neanderthal"
      {:version "0.41.0",
       :exclusions [org.jcuda/jcuda-natives org.jcuda/jcublas-natives],
@@ -581,12 +581,12 @@
   :is-no-exit false},
  :version
  {:release
-  {:name "0.2.13-alpha-03",
+  {:name "0.2.14-alpha-issue174-01",
    :major 0,
    :minor 2,
-   :patch 13,
-   :revision "alpha-03",
-   :date "2021-10-10"},
+   :patch 14,
+   :revision "alpha-issue174-01",
+   :date "2022-01-17"},
   :ws {:type :toolsdeps2, :breaking 1, :non-breaking 0}},
  :ws-dir "USER-HOME/source/polylith/examples/local-dep",
  :ws-local-dir "examples/local-dep",

--- a/scripts/output/polylith1/deps-migrated.txt
+++ b/scripts/output/polylith1/deps-migrated.txt
@@ -17,7 +17,7 @@
   command        .  x  .  x  x  x  x  x  x  x  x  .  .  x  x  .  x  .  x  .  x  x  x  x  x  x  x
   common         .  .  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .  .  .
   creator        .  .  .  x  .  .  x  x  .  .  .  .  .  .  .  t  .  .  .  .  x  .  .  .  .  .  .
-  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  .
+  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  x  .  .  .  .  .  .
   file           .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   git            .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   help           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .
@@ -36,7 +36,7 @@
   validator      .  .  .  x  .  x  .  .  .  .  .  x  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   version        .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
   workspace      .  .  .  x  .  x  x  .  .  .  .  x  .  .  .  t  .  x  .  .  x  x  .  .  .  .  .
-  workspace-clj  .  .  .  x  .  .  x  x  .  x  .  x  .  .  .  .  .  .  x  .  x  x  x  .  .  .  .
+  workspace-clj  .  .  .  x  .  x  x  x  .  x  .  x  .  .  .  .  .  .  x  .  x  x  x  .  .  .  .
   ws-explorer    .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   ws-file        .  .  .  x  .  .  x  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .
   poly-cli       .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  .  .  .  .  .

--- a/scripts/output/polylith1/deps.txt
+++ b/scripts/output/polylith1/deps.txt
@@ -17,7 +17,7 @@
   command        .  x  .  x  x  x  x  x  x  x  x  .  .  x  x  .  x  .  x  .  x  x  x  x  x  x  x
   common         .  .  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .  .  .
   creator        .  .  .  x  .  .  x  x  .  .  .  .  .  .  .  t  .  .  .  .  x  .  .  .  .  .  .
-  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  .
+  deps           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  x  .  .  .  .  .  .
   file           .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   git            .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   help           .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  x  .  .  .  .
@@ -36,7 +36,7 @@
   validator      .  .  .  x  .  x  .  .  .  .  .  x  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   version        .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .
   workspace      .  .  .  x  .  x  x  .  .  .  .  x  .  .  .  t  .  x  .  .  x  x  .  .  .  .  .
-  workspace-clj  .  .  .  x  .  .  x  x  .  x  .  x  .  .  .  .  .  .  x  .  x  x  x  .  .  .  .
+  workspace-clj  .  .  .  x  .  x  x  x  .  x  .  x  .  .  .  .  .  .  x  .  x  x  x  .  .  .  .
   ws-explorer    .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  .  .
   ws-file        .  .  .  x  .  .  x  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .
   poly-cli       .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  .  .  .  .  .

--- a/scripts/output/polylith1/libs-migrated.txt
+++ b/scripts/output/polylith1/libs-migrated.txt
@@ -1,5 +1,5 @@
-                                                                                                      w
-                                                                                                      o
+                                                                                                      w   
+                                                                                                      o   
                                                                                                       r  w
                                                                                                       k  s
                                                                                                    v  s  -
@@ -13,7 +13,7 @@
   library                           version        type      KB   api  poly   dev   s  e  r  l  p  r  j  r
   -------------------------------------------------------------   ---------   ---   ----------------------
   djblue/portal                     0.18.1         maven    768    -    x      x    .  .  .  .  x  .  .  .
-  io.github.seancorfield/build-clj  6e962ef        git       78    -    -      x    .  .  .  .  .  .  .  .
+  io.github.seancorfield/build-clj  6e962ef        git       39    -    -      x    .  .  .  .  .  .  .  .
   me.raynes/fs                      1.4.6          maven     10    x    x      x    .  x  .  .  .  .  .  .
   metosin/malli                     0.7.1          maven     54    x    x      x    .  .  .  .  .  x  .  .
   mount/mount                       0.1.16         maven      8    -    -      x    .  .  .  .  .  .  .  .

--- a/scripts/output/polylith1/libs.txt
+++ b/scripts/output/polylith1/libs.txt
@@ -1,5 +1,5 @@
-                                                                                                      w
-                                                                                                      o
+                                                                                                      w   
+                                                                                                      o   
                                                                                                       r  w
                                                                                                       k  s
                                                                                                    v  s  -
@@ -13,7 +13,7 @@
   library                           version        type      KB   api  poly   dev   s  e  r  l  p  r  j  r
   -------------------------------------------------------------   ---------   ---   ----------------------
   djblue/portal                     0.18.1         maven    768    -    x      x    .  .  .  .  x  .  .  .
-  io.github.seancorfield/build-clj  6e962ef        git       78    -    -      x    .  .  .  .  .  .  .  .
+  io.github.seancorfield/build-clj  6e962ef        git       39    -    -      x    .  .  .  .  .  .  .  .
   me.raynes/fs                      1.4.6          maven     10    x    x      x    .  x  .  .  .  .  .  .
   metosin/malli                     0.7.1          maven     54    x    x      x    .  .  .  .  .  x  .  .
   mount/mount                       0.1.16         maven      8    -    -      x    .  .  .  .  .  .  .  .


### PR DESCRIPTION
Handle the case when only :git/sha (or :sha) is given in a library dependency.
Calculate library sizes correctly (it didn't in some cases, but now it should).