### PR TITLE
Bugfix: Correct hash-sum denotation

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -244,5 +244,5 @@
                            (str/split #" ")
                            (first))]
           (println (str "Shasum for " project ": " sha-sum))
-          (spit (str "artifacts/" tar-file ".sha1") sha-sum))
+          (spit (str "artifacts/" tar-file ".sha256") sha-sum))
         (b/delete {:path (str "artifacts/" project)})))))


### PR DESCRIPTION
The hash-sum is a sha256-sum not a sha1-sum. This leads to confusion.