### PR TITLE
fix: calculation of file size for rare cases

### DIFF
--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -16,7 +16,8 @@
 
 (defn size [path]
   (cond (fs/directory? path) (apply + (pmap size (.listFiles (io/file path))))
-        (fs/file? path) (fs/size path)))
+        (fs/file? path) (fs/size path)
+        :else 0))
 
 (defn delete-file [path]
   (execute-fn #(io/delete-file path true)


### PR DESCRIPTION
`poly info` was failing for me because the poly command was walking over a directory with a `.#test.clj` file (emacs) which apparently was neither a file nor a directory. 

This commit adds a default `0` size for these exceptions to prevent a Nullpointer exception in the addition.