### PR TITLE
fix: clojure files are not hidden

### DIFF
--- a/components/common/src/polylith/clj/core/common/core.clj
+++ b/components/common/src/polylith/clj/core/common/core.clj
@@ -48,9 +48,18 @@
     top-namespace
     (str top-namespace ".")))
 
+(defn path->filename [path]
+  (last (str/split path #"/")))
+    
+(defn hidden-file? [path]
+  (str/starts-with? (path->filename path) "."))
+
 (defn filter-clojure-paths [paths]
-  (filterv #(or (str/ends-with? % ".clj")
-                (str/ends-with? % ".cljc"))
+  (filterv #(and 
+              (or (str/ends-with? % ".clj")
+                  (str/ends-with? % ".cljc"))
+              ;; E.g. temporary emacs files might give problems
+              (not (hidden-file? %)))
            paths))
 
 (defn find-brick [name {:keys [components bases]}]


### PR DESCRIPTION
This PR contains a fix for the following issue.

I had cryptic errors while running tests:

```
Caused by: Syntax error compiling quote at (0:0).
Wrong number of args (0) passed to quote
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7132)
	at clojure.lang.Compiler.analyze(Compiler.java:6806)
 	at clojure.lang.Compiler.analyze(Compiler.java:6762)
	at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3900)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7126)
	at clojure.lang.Compiler.analyze(Compiler.java:6806)
	at clojure.lang.Compiler.analyze(Compiler.java:6762)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6137)
	at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5479)
	at clojure.lang.Compiler$FnExpr.parse(Compiler.java:4041)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7122)
	at clojure.lang.Compiler.analyze(Compiler.java:6806)
	at clojure.lang.Compiler.eval(Compiler.java:7191)
	at clojure.lang.Compiler.eval(Compiler.java:7183)
	at clojure.lang.Compiler.eval(Compiler.java:7149)
	at clojure.core$eval.invokeStatic(core.clj:3215)
	at clojure.core$eval.invoke(core.clj:3211)
	at clojure.core$eval51877.invokeStatic(NO_SOURCE_FILE:0)
	at clojure.core$eval51877.invoke(NO_SOURCE_FILE)
	at clojure.lang.Compiler.eval(Compiler.java:7194)
	at clojure.lang.Compiler.eval(Compiler.java:7149)
	... 41 more
Caused by: clojure.lang.ExceptionInfo: Wrong number of args (0) passed to quote {:form (quote)}
	at clojure.lang.Compiler$ConstantExpr$Parser.parse(Compiler.java:2016)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7124)
	... 61 more
```

After running again with `test :verbose`. I saw empty namespace names: 

```
Running tests from the myproject project, including 0 brick and 1 project: myproject
# test-statements:
[(do (clojure.core/use (quote clojure.test)) (clojure.core/require (quote myproject.hello-test)) (clojure.test/run-tests (quote myproject.hello-test))) (do (clojure.core/use (quote clojure.test)) (clojure.core/require (quote )) (clojure.test/run-tests (quote )))]
```

It turned that the test directory contained temporary emacs files, e.g. `.#hello.clj`. When these are filtered (in this commit) things work fine.

Note that hidden files could be filtered elsewhere (e.g. [here](https://github.com/polyfy/polylith/blob/f54afe3e4e38f41eae8c29d4fe65616eba79c7a6/components/file/src/polylith/clj/core/file/core.clj#L130)), but I figured it made most sense to filter them when specifically asking for clojure files.