### PR TITLE
Remove function with empty body

### DIFF
--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -4,10 +4,10 @@
 (def major 0)
 (def minor 2)
 (def patch 15)
-(def revision "alpha-issue209-01")
+(def revision "alpha-issue235-01")
 (def name (str major "." minor "." patch "-" revision))
 
-(def date "2022-06-06")
+(def date "2022-06-17")
 
 (defn version
   ([ws-type]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_paths.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_paths.clj
@@ -9,8 +9,6 @@
     (mapv #(str "projects/" project-name "/" %)
           src-paths)))
 
-(defn source-paths [project-name is-dev src-paths])
-
 (defn source-dirs [ws-dir project-name entries src-path-criteria]
   (mapv #(str ws-dir "/" %)
         (select/paths entries c/project? src-path-criteria (c/=name project-name))))

--- a/development/src/dev/jocke.clj
+++ b/development/src/dev/jocke.clj
@@ -41,7 +41,10 @@
 
 ;(info/info workspace nil)
 
-;(command/execute-command (user-input/extract-params ["info"]))
+;(command/execute-command (user-input/extract-params ["info" ":all" "project:poly" "brick:-"]))
+;(command/execute-command (user-input/extract-params ["ws" "get:changes:project-to-projects-to-test:poly" ":all" "project:poly" "brick:-"]))
+;(command/execute-command (user-input/extract-params ["test" ":all" "project:poly" "brick:-"]))
+
 ;(command/execute-command (user-input/extract-params ["test"]))
 
 (:projects workspace)

--- a/doc/commands.md
+++ b/doc/commands.md
@@ -29,7 +29,7 @@ poly help
 ```
 
 ```
-  Poly 0.2.15-alpha-issue206-01 (2022-05-14) - https://github.com/polyfy/polylith
+  Poly 0.2.15-alpha-issue235-01 (2022-06-17) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 
@@ -959,3 +959,4 @@ poly help
     poly ws out:ws.edn
     poly ws color-mode:none > ws.edn
 ```
+

--- a/scripts/output/help/01-help.txt
+++ b/scripts/output/help/01-help.txt
@@ -1,4 +1,4 @@
-  Poly 0.2.15-alpha-issue206-01 (2022-05-14) - https://github.com/polyfy/polylith
+  Poly 0.2.15-alpha-issue235-01 (2022-06-17) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/scripts/output/ws-state-settings.txt
+++ b/scripts/output/ws-state-settings.txt
@@ -45,7 +45,8 @@
  :tag-patterns {:stable "stable-*", :release "v[0-9]*"},
  :thousand-separator ",",
  :top-namespace "se.example",
- :user-config-filename "/Users/joakimtengstrand/.config/polylith/config.edn",
+ :user-config-filename
+ "/Users/joakimtengstrand/.config/polylith/config.edn",
  :user-home "/Users/joakimtengstrand",
  :vcs
  {:name "git",


### PR DESCRIPTION
A function with an empty body was committed by mistake which override a function that calculated the namespaces. The result was that no project tests was executed.

Fixes issue #235 