### PR TITLE
Do not use context classloader

### DIFF
--- a/components/common/src/polylith/clj/core/common/class_loader.clj
+++ b/components/common/src/polylith/clj/core/common/class_loader.clj
@@ -17,7 +17,7 @@
     ext))
 
 (defmacro with-classloader [class-loader & body]
-  `(binding [*use-context-classloader* true]
+  `(binding [*use-context-classloader* false]
      (let [cl# (.getContextClassLoader (Thread/currentThread))]
        (try (.setContextClassLoader (Thread/currentThread) ~class-loader)
             ~@body


### PR DESCRIPTION
The default is already `true` so I am not sure why this `binding` was present, but changing it to `false` seems to prevent some edge case classloader issues for tests that use fork/join thread pools and `reify` or `proxy` new classes in those threads.