### PR TITLE
Request GC after each project test suite runs

### DIFF
--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -182,7 +182,8 @@
           (println)
           (transduce
             (comp (map #(test-opts workspace settings changes % is-verbose color-mode))
-                  (map run-tests-for-project))
+                  (map run-tests-for-project)
+                  (map #(do (System/gc) %)))
             (completing (fn [_ x] (cond-> x (not x) (reduced))))
             true
             projects-to-test)))


### PR DESCRIPTION
This can help reduce overall memory usage for very large Polylith projects when a lot of projects (and a lot of components) need to be tested in a single `poly test` run.