### PR TITLE
Adds support for an external test runner per #260

### DIFF
--- a/.clj-kondo/babashka/sci/config.edn
+++ b/.clj-kondo/babashka/sci/config.edn
@@ -1,0 +1,1 @@
+{:hooks {:macroexpand {sci.core/copy-ns sci.core/copy-ns}}}

--- a/.clj-kondo/babashka/sci/sci/core.clj
+++ b/.clj-kondo/babashka/sci/sci/core.clj
@@ -1,0 +1,9 @@
+(ns sci.core)
+
+(defmacro copy-ns
+  ([ns-sym sci-ns]
+   `(copy-ns ~ns-sym ~sci-ns nil))
+  ([ns-sym sci-ns opts]
+   `[(quote ~ns-sym)
+     ~sci-ns
+     (quote ~opts)]))

--- a/.clj-kondo/metosin/malli/config.edn
+++ b/.clj-kondo/metosin/malli/config.edn
@@ -1,0 +1,2 @@
+{:lint-as {malli.experimental/defn schema.core/defn}
+ :linters {:unresolved-symbol {:exclude [(malli.core/=>)]}}}

--- a/.lsp/config.edn
+++ b/.lsp/config.edn
@@ -1,0 +1,1 @@
+{:source-aliases #{:dev :test}}

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -50,21 +50,18 @@
 (defprotocol ExternalTestRunner
   "Implement to provide an external process namespace for a test runner.
   `external-process-namespace`
-    - called first
     - if nil (default), tests are run in isolated classloaders in process,
     - if non-nil, assumed to be a symbol or string identifying the main
       namespace of an external test-runner to be used.
       - when an external test-runner is used, no classloader will be created
         and the `setup-fn`/`teardown-fn` should be run by that test-runner
         instead of by `poly` itself; the main namespace will be invoked as a
-        `java` subprocess with the following arguments:
-        - $POLY_TEST_JAVA_OPTS -- `java` options passed via that environment
-          variable, if defined
-        - -cp <classpath> -- the list of paths that would otherwise be used
-          to create the isolated classloader
-        - setup-fn -- optional (fully-qualified name)
-        - <nses> -- the list of namespaces to test as separate arguments
-        - teardown-fn -- optional (fully-qualified name)"
+        `java` subprocess with arguments detemined by the test runner;
+      - the external test runner's `run-tests` function is passed:
+        - :process-ns -- the name of the main namespace as above
+        - :setup-fn -- the fully-qualified name of the project setup function
+        - :teardown-fn -- similarly for the teardown function
+        - :all-paths -- a sequence of all the elements of the classpath"
   (external-process-namespace [this]))
 
 (defn is-external-test-runner?

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -46,3 +46,28 @@
   (test-sources-present? [this])
   (tests-present? [this {:keys [class-loader eval-in-project] :as opts}])
   (run-tests [this {:keys [class-loader color-mode eval-in-project is-verbose] :as opts}]))
+
+(defprotocol ExternalTestRunner
+  "Implement to provide an external process namespace for a test runner.
+  `external-process-namespace`
+    - called first
+    - if nil (default), tests are run in isolated classloaders in process,
+    - if non-nil, assumed to be a symbol or string identifying the main
+      namespace of an external test-runner to be used.
+      - when an external test-runner is used, no classloader will be created
+        and the `setup-fn`/`teardown-fn` should be run by that test-runner
+        instead of by `poly` itself; the main namespace will be invoked as a
+        `java` subprocess with the following arguments:
+        - $POLY_TEST_JAVA_OPTS -- `java` options passed via that environment
+          variable, if defined
+        - -cp <classpath> -- the list of paths that would otherwise be used
+          to create the isolated classloader
+        - setup-fn -- optional (fully-qualified name)
+        - <nses> -- the list of namespaces to test as separate arguments
+        - teardown-fn -- optional (fully-qualified name)"
+  (external-process-namespace [this]))
+
+(defn is-external-test-runner?
+  "Returns true iff the test runner is an external process."
+  [runner]
+  (satisfies? ExternalTestRunner runner))

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -20,14 +20,14 @@
       (println (str "Couldn't resolve libraries for the " (color/project name color-mode) " project: " e))
       (throw e))))
 
-(defn execute-fn [function fn-type project-name class-loader color-mode]
+(defn execute-fn [function fn-type project-name class-loader-delay color-mode]
   (if function
     (do
       (println (str "Running test " fn-type " for the " (color/project project-name color-mode)
                     " project: " function))
       (try
         (if (= :missing-fn
-               (common/eval-in class-loader
+               (common/eval-in (deref class-loader-delay)
                                `(if-let [~'fun (clojure.core/requiring-resolve '~function)]
                                   (~'fun '~project-name)
                                   :missing-fn)))
@@ -57,26 +57,31 @@
             (throw e))))))
 
 (defn run-tests-for-project-with-test-runner
-  [{:keys [test-runner setup-delay teardown-delay color-mode runner-opts project]}]
+  [{:keys [test-runner color-mode runner-opts project
+           ;; these are only present for in-process test runners:
+           setup-exec-fn teardown-exec-fn]}]
   (let [for-project-using-runner
         (str "for the " (color/project (:name project) color-mode)
              " project using test runner: "
              (test-runner-contract/test-runner-name test-runner))]
     (if-not (test-runner-contract/tests-present? test-runner runner-opts)
       (println (str "No tests to run " for-project-using-runner "."))
-      (if (deref setup-delay)
+      (if (or (nil? setup-exec-fn) (setup-exec-fn))
         (try
           (println (str "Running tests " for-project-using-runner "..."))
           (test-runner-contract/run-tests test-runner runner-opts)
-          (catch Throwable e (deref teardown-delay) (throw e)))
+          (finally
+            (when-not (or (nil? teardown-exec-fn) (teardown-exec-fn))
+              (throw (ex-info "Test terminated due to teardown failure"
+                              {:project project})))))
         (throw (ex-info (str "Test terminated due to setup failure") {:project project}))))))
 
 (defn ex-causes [ex]
   (str/join "; " (take-while some? (iterate ex-cause ex))))
 
-(defn ->eval-in-project [class-loader]
+(defn ->eval-in-project [class-loader-delay]
   (fn [form]
-    (try (common/eval-in class-loader form)
+    (try (common/eval-in (deref class-loader-delay) form)
          (catch Throwable e
            (throw (ex-info
                    (str "Error while evaluating form " form
@@ -108,26 +113,28 @@
               create-test-runner)]
     (when (seq test-runners-seeing-test-sources)
       (let [lib-paths (resolve-deps project settings is-verbose color-mode)
-            all-paths (into #{} cat [(:src paths) (:test paths) lib-paths])
-            class-loader (common/create-class-loader all-paths color-mode)
-            setup!* (delay (execute-fn setup-fn "setup" name class-loader color-mode))
-            setup-failed? #(and (realized? setup!*) (not (deref setup!*)))
-            setup-succeeded? #(and (realized? setup!*) (deref setup!*))
-            teardown!* (delay (execute-fn teardown-fn "teardown" name class-loader color-mode))
-            runner-opts (merge opts
-                               {:class-loader class-loader
-                                :eval-in-project (->eval-in-project class-loader)})]
+            all-paths (into [] cat [(:src paths) (:test paths) lib-paths])
+            class-loader-delay (delay (common/create-class-loader all-paths color-mode))]
         (when is-verbose (println (str "# paths:\n" all-paths "\n")))
         (doseq [current-test-runner test-runners-seeing-test-sources]
-          (when-not (setup-failed?)
-            (->> {:test-runner current-test-runner
-                  :setup-delay setup!*
-                  :teardown-delay teardown!*
-                  :runner-opts runner-opts}
+          (let [process-ns (when (test-runner-contract/is-external-test-runner? current-test-runner)
+                             (test-runner-contract/external-process-namespace current-test-runner))
+                runner-opts (if process-ns
+                              {:process-ns process-ns
+                               :setup-fn setup-fn
+                               :teardown-fn teardown-fn
+                               :all-paths all-paths}
+                              {:class-loader-delay class-loader-delay
+                               :eval-in-project (->eval-in-project class-loader-delay)})]
+            (->> (if process-ns
+                   {}
+                   {:setup-exec-fn #(execute-fn setup-fn "setup" name class-loader-delay color-mode)
+                    :teardown-exec-fn #(execute-fn teardown-fn "teardown" name class-loader-delay color-mode)})
+                 (merge {:test-runner current-test-runner
+                         :runner-opts (merge opts runner-opts)})
                  (merge opts)
                  (run-tests-for-project-with-test-runner))))
-        (when (setup-succeeded?)
-          (deref teardown!*))))))
+        true))))
 
 (defn affected-by-changes? [{:keys [name]} {:keys [project-to-bricks-to-test project-to-projects-to-test]}]
   (seq (concat (project-to-bricks-to-test name)

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -4,7 +4,7 @@
 (def major 0)
 (def minor 2)
 (def patch 16)
-(def revision "alpha-issue247")
+(def revision "alpha-issue260")
 (def name (str major "." minor "." patch "-" revision))
 
 (def date "2022-10-27")


### PR DESCRIPTION
Minimal changes to support #260 

This does not include the external test runner itself, which can be a separate project. This does not provide any documentation on the new `ExternalTestRunner` protocol or how to build other external test runners. I don't know what was added to the Polylith docs or tool repo when the pluggable test runner machinery was added, but I expect that something similar will need adding by way of documentation for this?

See https://github.com/seancorfield/polylith-external-test-runner