### PR TITLE
External Test Runner Support

### DIFF
--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -47,10 +47,20 @@
   ```
   (defn create [{:keys [workspace project test-settings is-verbose color-mode changes]}]
     ...
-    (reify TestRunner ...)
 
-    ; Optional, only if you want an external test runner
-    (reify ExternalTestRunner ...))
+    (reify
+      test-runner-contract/TestRunner
+      (test-runner-name [this] ...)
+
+      (test-sources-present? [this] ...)
+
+      (tests-present? [this runner-opts] ...)
+
+      (run-tests [this runner-opts] ...)
+
+      ; Optional, only if you want an external test runner
+      test-runner-contract/ExternalTestRunner
+      (external-process-namespace [this] ...)))
   ```
 
   `workspace` passed to the constructor will contain `:user-input`, which
@@ -58,12 +68,12 @@
 
   Add your constructor function in the workspace.edn:
 
-  {:test {:create-test-runner my.namespace/create} ; to use it globally
+  {:test {:create-test-runner [my.namespace/create]} ; to use it globally
 
    :projects {; to use it only for a project
-              \"project-a\" {:test {:create-test-runner my.namespace/create}}
+              \"project-a\" {:test {:create-test-runner [my.namespace/create]}}
               ; to reset the global setting to default
-              \"project-b\" {:test {:create-test-runner :default}}}}"
+              \"project-b\" {:test {:create-test-runner [:default]}}}}"
 
   (test-runner-name [this]
     "Returns a printable name that the poly tool can print out for

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -1,7 +1,7 @@
 (ns polylith.clj.core.test-runner-contract.interface)
 
 (defprotocol TestRunner
-  "Implement to supply a custom test runner
+  "Implement this protocol to supply a custom test runner.
 
   `test-runner-name`
     - should return a printable name that the test orchestrator can print out for information purposes
@@ -46,3 +46,23 @@
   (test-sources-present? [this])
   (tests-present? [this {:keys [class-loader eval-in-project] :as opts}])
   (run-tests [this {:keys [class-loader color-mode eval-in-project is-verbose] :as opts}]))
+
+(defprotocol ExternalTestRunner
+  "Extends the `TestRunner` protocol to provide an external process namespace for a test runner. Polylith uses
+  a classloader approach to run tests in isolation by default. `ExternalTestRunner` skips the classloaders and
+  uses `java` subprocesses.
+
+  `external-process-namespace`
+    - if returns nil (default), tests are run in isolated classloaders within the same process,
+    - if returns non-nil, it must be a symbol or string identifying the main namespace of an
+      external test-runner to be used.
+      - when an external test-runner is used, no classloader will be created
+        and the `setup-fn`/`teardown-fn` should be run by that test-runner
+        instead of by `poly` itself; the main namespace will be invoked as a
+        `java` subprocess with arguments determined by the test runner;
+      - the external test runner's `run-tests` function is passed:
+        - :process-ns -- the name of the main namespace as above
+        - :setup-fn -- the fully-qualified name of the project setup function
+        - :teardown-fn -- similarly for the teardown function
+        - :all-paths -- a sequence of all the elements of the classpath"
+  (external-process-namespace [this]))

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -66,14 +66,42 @@
   `workspace` passed to the constructor will contain `:user-input`, which
   can be used to receive additional parameters for runtime configuration.
 
-  Add your constructor function in the workspace.edn:
+  Add your constructor function in the workspace.edn. To add a single global
+  test runner, use the `:test` key:
 
-  {:test {:create-test-runner [my.namespace/create]} ; to use it globally
+  {:test {:create-test-runner my.namespace/create}
 
-   :projects {; to use it only for a project
-              \"project-a\" {:test {:create-test-runner [my.namespace/create]}}
-              ; to reset the global setting to default
-              \"project-b\" {:test {:create-test-runner [:default]}}}}"
+   :projects {\"project-a\" {:alias \"a\"}
+              \"project-b\" {:alias \"b\"}}}
+
+  To add a multiple global test runners, use the vector variant inside the
+  `:test` key. The following example will add three test runners globally
+  where the last one is the default test runner.
+
+  {:test {:create-test-runner [my.namespace/create se.example/create :default]}
+
+   :projects {\"project-a\" {:alias \"a\"}
+              \"project-b\" {:alias \"b\"}}}
+
+  To add a custom test runner for a specific project, use the `:test` key
+  in the project configuration. You can also add multiple test runners with
+  using the vector variant.
+
+  {:projects {\"project-a\" {:alias \"a\"
+                             :test {:create-test-runner my.namespace/create}}
+              \"project-b\" {:alias \"b\"
+                             :test {:create-test-runner [my.namespace/create
+                                                         :default]}}}}
+
+  Adding a test runner definition to a project will override the global test
+  runner. The project-a will use the global test runner, `my.namespace/create`
+  whereas project-b will use the default test runner.
+
+  {:test {:create-test-runner my.namespace/create}
+
+   :projects {\"project-a\" {:alias \"a\"}
+              \"project-b\" {:alias \"b\"
+                             :test {:create-test-runner :default}}}}"
 
   (test-runner-name [this]
     "Returns a printable name that the poly tool can print out for

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/verifiers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/verifiers.clj
@@ -7,5 +7,8 @@
 (defn valid-test-runner? [candidate]
   (core/valid-test-runner? candidate))
 
+(defn valid-external-test-runner? [candidate]
+  (core/valid-external-test-runner? candidate))
+
 (defn ensure-valid-test-runner [candidate]
   (core/ensure-valid-test-runner candidate))

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/verifiers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/verifiers.clj
@@ -16,6 +16,9 @@
 (defn valid-test-runner? [candidate]
   (satisfies? test-runner-contract/TestRunner candidate))
 
+(defn valid-external-test-runner? [candidate]
+  (satisfies? test-runner-contract/ExternalTestRunner candidate))
+
 (defn ensure-valid-test-runner [candidate]
   (when-not (valid-test-runner? candidate)
     (throw (ex-info "Test runners must satisfy the TestRunner protocol" {:candidate candidate})))

--- a/components/test-runner-orchestrator/deps.edn
+++ b/components/test-runner-orchestrator/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
  :deps {}
- :aliases {:test {:extra-paths []
+ :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -56,17 +56,17 @@
                           " project: " e))
             (throw e))))))
 
-(defn execute-setup-fn [project color-mode {:keys [setup-fn runner-ns class-loader]}]
+(defn execute-setup-fn [project color-mode {:keys [setup-fn process-ns class-loader]}]
   ;; DO NOT run setup-fn if the current test runner is an external process test runner.
   ;; The external test runner will run setup and teardown functions itself.
-  (if (or runner-ns (nil? setup-fn))
+  (if (or process-ns (nil? setup-fn))
     true
     (execute-fn setup-fn "setup" (:name project) class-loader color-mode)))
 
-(defn execute-teardown-fn [project color-mode {:keys [teardown-fn runner-ns class-loader]} throw?]
+(defn execute-teardown-fn [project color-mode {:keys [teardown-fn process-ns class-loader]} throw?]
   ;; DO NOT run teardown-fn if the current test runner is an external process test runner.
   ;; The external test runner will run setup and teardown functions itself.
-  (when-not runner-ns
+  (when-not process-ns
     (when teardown-fn
       (when-not (execute-fn teardown-fn "teardown" (:name project) class-loader color-mode)
         (when throw?

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -113,12 +113,12 @@
                    {:form form}
                    e))))))
 
-(defn test-opts [workspace
-                 settings
-                 changes
-                 {:keys [name] :as project}
-                 is-verbose
-                 color-mode]
+(defn ->test-opts [workspace
+                   settings
+                   changes
+                   {:keys [name] :as project}
+                   is-verbose
+                   color-mode]
   {:workspace workspace
    :project project
    :changes changes
@@ -209,12 +209,9 @@
           (print-projects-to-test projects-to-test color-mode)
           (print-bricks-to-test component-names base-names bricks-to-test color-mode)
           (println)
-          (transduce
-            (comp (map #(test-opts workspace settings changes % is-verbose color-mode))
-                  (map run-tests-for-project)
-                  (map #(do (System/gc) %)))
-            (completing (fn [_ x] (cond-> x (not x) (reduced))))
-            true
-            projects-to-test)))
+          (doseq [project projects-to-test]
+            (let [test-opts (->test-opts workspace settings changes project is-verbose color-mode)]
+              (run-tests-for-project test-opts)
+              (System/gc)))))
       (print-execution-time start-time)
       true)))

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -56,19 +56,48 @@
                           " project: " e))
             (throw e))))))
 
+(defn execute-setup-fn [project color-mode {:keys [setup-fn runner-ns class-loader]}]
+  ;; DO NOT run setup-fn if the current test runner is an external process test runner.
+  ;; The external test runner will run setup and teardown functions itself.
+  (if (or runner-ns (nil? setup-fn))
+    true
+    (execute-fn setup-fn "setup" (:name project) class-loader color-mode)))
+
+(defn execute-teardown-fn [project color-mode {:keys [teardown-fn runner-ns class-loader]} throw?]
+  ;; DO NOT run teardown-fn if the current test runner is an external process test runner.
+  ;; The external test runner will run setup and teardown functions itself.
+  (when-not runner-ns
+    (when teardown-fn
+      (when-not (execute-fn teardown-fn "teardown" (:name project) class-loader color-mode)
+        (when throw?
+          (throw (ex-info "Test terminated due to teardown failure"
+                          {:project project
+                           :teardown-failed? true})))))))
+
 (defn run-tests-for-project-with-test-runner
-  [{:keys [test-runner setup-delay teardown-delay color-mode runner-opts project]}]
+  [{:keys [test-runner color-mode runner-opts project]}]
   (let [for-project-using-runner
         (str "for the " (color/project (:name project) color-mode)
              " project using test runner: "
              (test-runner-contract/test-runner-name test-runner))]
     (if-not (test-runner-contract/tests-present? test-runner runner-opts)
       (println (str "No tests to run " for-project-using-runner "."))
-      (if (deref setup-delay)
+      (if (execute-setup-fn (:name project) color-mode runner-opts)
         (try
           (println (str "Running tests " for-project-using-runner "..."))
           (test-runner-contract/run-tests test-runner runner-opts)
-          (catch Throwable e (deref teardown-delay) (throw e)))
+
+          ;; Run the teardown function and throw if it fails.
+          (execute-teardown-fn project color-mode runner-opts true)
+
+          (catch Throwable e
+            ;; If this exception is due to running teardown function, skip running
+            ;; teardown function again.
+            (when-not (-> e ex-data :teardown-failed?)
+              ;; Run the teardown function and DO NOT throw if it fails. We want to
+              ;; throw the actual exception received from the test runner.
+              (execute-teardown-fn project color-mode runner-opts false))
+            (throw e)))
         (throw (ex-info (str "Test terminated due to setup failure") {:project project}))))))
 
 (defn ex-causes [ex]
@@ -99,7 +128,7 @@
 
 (defn run-tests-for-project [{:keys [workspace project test-settings is-verbose color-mode] :as opts}]
   (let [{:keys [settings]} workspace
-        {:keys [name paths]} project
+        {:keys [paths]} project
         {:keys [create-test-runner setup-fn teardown-fn]} test-settings
         test-runners-seeing-test-sources
         (into []
@@ -108,26 +137,26 @@
               create-test-runner)]
     (when (seq test-runners-seeing-test-sources)
       (let [lib-paths (resolve-deps project settings is-verbose color-mode)
-            all-paths (into #{} cat [(:src paths) (:test paths) lib-paths])
-            class-loader (common/create-class-loader all-paths color-mode)
-            setup!* (delay (execute-fn setup-fn "setup" name class-loader color-mode))
-            setup-failed? #(and (realized? setup!*) (not (deref setup!*)))
-            setup-succeeded? #(and (realized? setup!*) (deref setup!*))
-            teardown!* (delay (execute-fn teardown-fn "teardown" name class-loader color-mode))
-            runner-opts (merge opts
-                               {:class-loader class-loader
-                                :eval-in-project (->eval-in-project class-loader)})]
+            all-paths (into [] cat [(:src paths) (:test paths) lib-paths])
+            class-loader-delay (delay (common/create-class-loader all-paths color-mode))]
         (when is-verbose (println (str "# paths:\n" all-paths "\n")))
         (doseq [current-test-runner test-runners-seeing-test-sources]
-          (when-not (setup-failed?)
+          (let [process-ns (when (test-runner-verifiers/valid-external-test-runner? current-test-runner)
+                             (test-runner-contract/external-process-namespace current-test-runner))
+                runner-opts (cond-> {:setup-fn setup-fn
+                                     :teardown-fn teardown-fn
+                                     :all-paths all-paths}
+
+                                    process-ns
+                                    (assoc :process-ns process-ns)
+
+                                    (not process-ns)
+                                    (assoc :class-loader @class-loader-delay
+                                           :eval-in-project (->eval-in-project @class-loader-delay)))]
             (->> {:test-runner current-test-runner
-                  :setup-delay setup!*
-                  :teardown-delay teardown!*
-                  :runner-opts runner-opts}
+                  :runner-opts (merge opts runner-opts)}
                  (merge opts)
-                 (run-tests-for-project-with-test-runner))))
-        (when (setup-succeeded?)
-          (deref teardown!*))))))
+                 (run-tests-for-project-with-test-runner))))))))
 
 (defn affected-by-changes? [{:keys [name]} {:keys [project-to-bricks-to-test project-to-projects-to-test]}]
   (seq (concat (project-to-bricks-to-test name)

--- a/components/test-runner-orchestrator/test/polylith/clj/core/test_runner_orchestrator/core_test.clj
+++ b/components/test-runner-orchestrator/test/polylith/clj/core/test_runner_orchestrator/core_test.clj
@@ -1,0 +1,128 @@
+(ns polylith.clj.core.test-runner-orchestrator.core-test
+  (:require [clojure.test :refer :all]
+            [polylith.clj.core.test-runner-orchestrator.core :as core])
+  (:import (clojure.lang ExceptionInfo)))
+
+(defn ->mock-execute-fn [& {:keys [returns?] :or {returns? true}}]
+  (let [mock-state (atom {:call-args  []
+                          :call-count 0})
+        mock-fn (fn [& args]
+                  (swap! mock-state
+                         #(-> %
+                              (update :call-args conj (vec args))
+                              (update :call-count inc)))
+                  returns?)]
+    {:mock-fn mock-fn
+     :mock    mock-state}))
+
+(deftest execute-setup-fn--external-test-runner--do-nothing-and-return-true
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        setup-fn (fn [_project-name])]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-setup-fn {:name "test-project-name"} "light"
+                                          {:setup-fn   setup-fn
+                                           :process-ns 'test-process-ns})]
+        (is (true? result))
+        (is (zero? (:call-count @mock)))))))
+
+(deftest execute-setup-fn--in-process-test-runner-and-no-setup-fn--do-nothing-and-return-true
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-setup-fn {:name "test-project-name"} "light"
+                                          {:class-loader class-loader})]
+        (is (true? result))
+        (is (zero? (:call-count @mock)))))))
+
+(deftest execute-setup-fn--in-process-test-runner-and-with-setup-fn--execute-setup-fn
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        setup-fn (fn [_project-name])
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-setup-fn {:name "test-project-name"} "light"
+                                          {:setup-fn     setup-fn
+                                           :class-loader class-loader})]
+        (is (true? result))
+        (is (= 1 (:call-count @mock)))
+        (is (= [[setup-fn "setup" "test-project-name" class-loader "light"]]
+               (:call-args @mock)))))))
+
+(deftest execute-setup-fn--in-process-test-runner-and-with-setup-fn-returns-false--execute-setup-fn
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn :returns? false)
+        setup-fn (fn [_project-name])
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-setup-fn {:name "test-project-name"} "light"
+                                          {:setup-fn     setup-fn
+                                           :class-loader class-loader})]
+        (is (false? result))
+        (is (= 1 (:call-count @mock)))
+        (is (= [[setup-fn "setup" "test-project-name" class-loader "light"]]
+               (:call-args @mock)))))))
+
+(deftest execute-teardown-fn--external-test-runner--do-nothing-and-return-nil
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        teardown-fn (fn [_project-name])]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-teardown-fn {:name "test-project-name"} "light"
+                                             {:teardown-fn teardown-fn
+                                              :process-ns  'test-process-ns}
+                                             true)]
+        (is (nil? result))
+        (is (zero? (:call-count @mock)))))))
+
+(deftest execute-teardown-fn--in-process-test-runner-and-no-teardown-fn--do-nothing-and-return-nil
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-teardown-fn {:name "test-project-name"} "light"
+                                             {:class-loader class-loader}
+                                             false)]
+        (is (nil? result))
+        (is (zero? (:call-count @mock)))))))
+
+(deftest execute-teardown-fn--in-process-test-runner-and-with-teardown-fn-and-teardown-success--execute-teardown-and-return-nil
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn)
+        teardown-fn (fn [_project-name])
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-teardown-fn {:name "test-project-name"} "light"
+                                             {:teardown-fn  teardown-fn
+                                              :class-loader class-loader}
+                                             true)]
+        (is (nil? result))
+        (is (= 1 (:call-count @mock)))
+        (is (= [[teardown-fn "teardown" "test-project-name" class-loader "light"]]
+               (:call-args @mock)))))))
+
+(deftest execute-teardown-fn--in-process-test-runner-and-with-teardown-fn-and-teardown-fail-and-throws--execute-teardown-and-throw
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn :returns? false)
+        teardown-fn (fn [_project-name])
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (try
+        (core/execute-teardown-fn {:name "test-project-name"} "light"
+                                  {:teardown-fn  teardown-fn
+                                   :class-loader class-loader}
+                                  true)
+        (catch ExceptionInfo e
+          (is (= {:project          {:name "test-project-name"}
+                  :teardown-failed? true}
+                 (ex-data e)))))
+      (is (= 1 (:call-count @mock)))
+      (is (= [[teardown-fn "teardown" "test-project-name" class-loader "light"]]
+             (:call-args @mock))))))
+
+(deftest execute-teardown-fn--in-process-test-runner-and-with-teardown-fn-and-teardown-fail-and-not-throws--execute-teardown-and-return-nil
+  (let [{:keys [mock-fn mock]} (->mock-execute-fn :returns? false)
+        teardown-fn (fn [_project-name])
+        class-loader "test-class-loader"]
+    (with-redefs [core/execute-fn mock-fn]
+      (let [result (core/execute-teardown-fn {:name "test-project-name"} "light"
+                                             {:teardown-fn  teardown-fn
+                                              :class-loader class-loader}
+                                             false)]
+        (is (nil? result))
+        (is (= 1 (:call-count @mock)))
+        (is (= [[teardown-fn "teardown" "test-project-name" class-loader "light"]]
+               (:call-args @mock)))))))

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -4,10 +4,10 @@
 (def major 0)
 (def minor 2)
 (def patch 16)
-(def revision "alpha-issue247")
+(def revision "alpha-external-test-runner")
 (def name (str major "." minor "." patch "-" revision))
 
-(def date "2022-10-27")
+(def date "2022-11-20")
 
 (defn version
   ([ws-type]

--- a/components/workspace-clj/test/polylith/clj/core/workspace_clj/project_settings_test.clj
+++ b/components/workspace-clj/test/polylith/clj/core/workspace_clj/project_settings_test.clj
@@ -10,19 +10,17 @@
   (is (= {} (sut/convert {}))))
 
 (deftest simple-project
-  (is (= {"foo" {:test {:create-test-runner [default-test-runner-constructor]}}}
+  (is (= {"foo" {}}
          (sut/convert {:projects {"foo" {}}}))))
 
 (deftest legacy-test-vector
-  (is (= {"foo" {:test {:include ["bar"]
-                        :create-test-runner [default-test-runner-constructor]}}}
+  (is (= {"foo" {:test {:include ["bar"]}}}
          (sut/convert {:projects {"foo" {:test ["bar"]}}}))))
 
 (deftest global-test-spec
   (is (= {"foo" {:test {:overridden :with-project
                         :from-project :from-project
-                        :untouched :at-top
-                        :create-test-runner [default-test-runner-constructor]}}}
+                        :untouched :at-top}}}
          (sut/convert
           {:projects {"foo" {:test {:overridden :with-project
                                     :from-project :from-project}}}
@@ -31,25 +29,24 @@
 
 (deftest legacy-project+global-settings
   (is (= {"foo" {:test {:include ["bar"]
-                        :from-top :from-top
-                        :create-test-runner [default-test-runner-constructor]}}}
+                        :from-top :from-top}}}
          (sut/convert
           {:projects {"foo" {:test ["bar"]}}
            :test {:from-top :from-top}}))))
 
 (deftest test-runner-constructor-without-top-level
-  (is (= {"foo" {:test {:create-test-runner [default-test-runner-constructor]}}
-          "bar" {:test {:create-test-runner ['my.ns/create]}}
-          "baz" {:test {:create-test-runner [default-test-runner-constructor]}}}
+  (is (= {"foo" {}
+          "bar" {:test {:create-test-runner 'my.ns/create}}
+          "baz" {:test {:create-test-runner :default}}}
          (sut/convert
           {:projects {"foo" {}
                       "bar" {:test {:create-test-runner 'my.ns/create}}
                       "baz" {:test {:create-test-runner :default}}}}))))
 
 (deftest test-runner-constructor-with-top-level
-  (is (= {"foo" {:test {:create-test-runner ['global.test/create]}}
-          "bar" {:test {:create-test-runner ['my.ns/create]}}
-          "baz" {:test {:create-test-runner [default-test-runner-constructor]}}}
+  (is (= {"foo" {:test {:create-test-runner 'global.test/create}}
+          "bar" {:test {:create-test-runner 'my.ns/create}}
+          "baz" {:test {:create-test-runner :default}}}
          (sut/convert
           {:test {:create-test-runner 'global.test/create}
            :projects {"foo" {}
@@ -57,11 +54,11 @@
                       "baz" {:test {:create-test-runner :default}}}}))))
 
 (deftest multiple-test-runner-constructors
-  (is (= {"foo" {:test {:create-test-runner ['global.test/create default-test-runner-constructor]}}
-          "bar" {:test {:create-test-runner ['my.ns/create]}}
-          "baz" {:test {:create-test-runner [default-test-runner-constructor]}}
+  (is (= {"foo" {:test {:create-test-runner ['global.test/create :default]}}
+          "bar" {:test {:create-test-runner 'my.ns/create}}
+          "baz" {:test {:create-test-runner :default}}
           "qux" {:test {:create-test-runner ['other.ns/create
-                                             default-test-runner-constructor
+                                             :default
                                              'global.test/create]}}}
          (sut/convert
           {:test {:create-test-runner ['global.test/create :default]}

--- a/components/workspace/src/polylith/clj/core/workspace/settings.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings.clj
@@ -8,12 +8,24 @@
 (defn undefined-project [index project-name]
   [project-name {:alias (str "?" (inc index))}])
 
+(def default-test-runner
+  'polylith.clj.core.clojure-test-test-runner.interface/create)
+
+(defn add-default-test-runner-if-missing [acc [project-name {:keys [test] :as project}]]
+  (let [enriched-project (if (or (empty? test)
+                                 (empty? (:create-test-runner test)))
+                           (assoc project :test {:create-test-runner [default-test-runner]})
+                           project)]
+    (assoc acc project-name enriched-project)))
+
 (defn enrich-settings [settings projects]
   "Enrich project aliases with e.g.: '?1', '?2'"
   (let [conf-projects (merge {"development" {:alias "dev"}} (:projects settings))
         undefined-projects (set/difference (set (map :name projects))
                                            (set (map first (filter #(-> % second :alias)
                                                                    conf-projects))))
-        enriched-projects (merge (into {} (map-indexed undefined-project undefined-projects))
-                                 conf-projects)]
+        enriched-projects (reduce add-default-test-runner-if-missing
+                                  {}
+                                  (merge (into {} (map-indexed undefined-project undefined-projects))
+                                         conf-projects))]
     (assoc settings :projects enriched-projects)))

--- a/components/workspace/src/polylith/clj/core/workspace/settings.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings.clj
@@ -1,31 +1,8 @@
 (ns polylith.clj.core.workspace.settings
-  (:require [clojure.set :as set]))
-
-(defn src-test-name [{:keys [name]} src-name->short-name]
-  [name
-   (src-name->short-name name)])
-
-(defn undefined-project [index project-name]
-  [project-name {:alias (str "?" (inc index))}])
-
-(def default-test-runner
-  'polylith.clj.core.clojure-test-test-runner.interface/create)
-
-(defn add-default-test-runner-if-missing [acc [project-name {:keys [test] :as project}]]
-  (let [enriched-project (if (or (empty? test)
-                                 (empty? (:create-test-runner test)))
-                           (assoc project :test {:create-test-runner [default-test-runner]})
-                           project)]
-    (assoc acc project-name enriched-project)))
+  (:require [polylith.clj.core.workspace.settings.alias :as alias]
+            [polylith.clj.core.workspace.settings.test :as test]))
 
 (defn enrich-settings [settings projects]
-  "Enrich project aliases with e.g.: '?1', '?2'"
-  (let [conf-projects (merge {"development" {:alias "dev"}} (:projects settings))
-        undefined-projects (set/difference (set (map :name projects))
-                                           (set (map first (filter #(-> % second :alias)
-                                                                   conf-projects))))
-        enriched-projects (reduce add-default-test-runner-if-missing
-                                  {}
-                                  (merge (into {} (map-indexed undefined-project undefined-projects))
-                                         conf-projects))]
-    (assoc settings :projects enriched-projects)))
+  (-> settings
+      (alias/enrich-settings projects)
+      (test/enrich-settings)))

--- a/components/workspace/src/polylith/clj/core/workspace/settings/alias.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings/alias.clj
@@ -1,0 +1,30 @@
+(ns polylith.clj.core.workspace.settings.alias
+  (:require [clojure.set :as set]))
+
+(defn project-name->alias [index project-name]
+  [project-name (str "?" (inc index))])
+
+(defn inject-alias-reducer [acc [project-name alias]]
+  (update acc project-name assoc :alias alias))
+
+(defn inject-dev-alias-if-missing [project-settings]
+  (if (get-in project-settings ["development" :alias])
+    project-settings
+    (update project-settings "development" assoc :alias "dev")))
+
+(defn enrich-settings [settings projects]
+  "Enrich project aliases with e.g.: 'dev', '?1', '?2'"
+  (let [project-settings (:projects settings)
+        project-names (->> projects
+                           (map :name)
+                           (set))
+        project-names-without-alias (->> project-settings
+                                         (filter #(-> % second :alias))
+                                         (map first)
+                                         (set))
+        missing-project-names (set/difference project-names project-names-without-alias)
+        enriched-projects (->> missing-project-names
+                               (map-indexed project-name->alias)
+                               (reduce inject-alias-reducer project-settings)
+                               (inject-dev-alias-if-missing))]
+    (assoc settings :projects enriched-projects)))

--- a/components/workspace/src/polylith/clj/core/workspace/settings/test.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings/test.clj
@@ -1,0 +1,50 @@
+(ns polylith.clj.core.workspace.settings.test)
+
+(def default-test-runner
+  'polylith.clj.core.clojure-test-test-runner.interface/create)
+
+(def default-test-runner-aliases
+  #{nil :default})
+
+(defn add-default-test-runner-if-missing [project-settings]
+  (cond-> project-settings
+
+    (empty? (-> project-settings :test :create-test-runner))
+    (update :test assoc :create-test-runner [default-test-runner])))
+
+(defn convert-create-test-runner-to-vector [project-settings]
+  (let [test-runner-configuration (-> project-settings :test :create-test-runner)]
+    (cond-> project-settings
+
+            (not (coll? test-runner-configuration))
+            (update-in [:test :create-test-runner] vector))))
+
+(defn alias->default-test-runner [test-runner-constructor]
+  (if (contains? default-test-runner-aliases test-runner-constructor)
+    default-test-runner
+    test-runner-constructor))
+
+(defn replace-default-test-runner-constructors [test-runner-constructors]
+  (mapv alias->default-test-runner test-runner-constructors))
+
+(defn update-default-test-runner-constructors [project-settings]
+  (update-in project-settings [:test :create-test-runner]
+             replace-default-test-runner-constructors))
+
+(defn enrich-test-settings [acc [project-name project-settings]]
+  (let [enriched-project-settings (-> project-settings
+                                      (convert-create-test-runner-to-vector)
+                                      (update-default-test-runner-constructors)
+                                      (add-default-test-runner-if-missing))]
+    (assoc acc project-name enriched-project-settings)))
+
+(defn enrich-settings
+  "Enrich the project's test configuration with test runners. It replaces
+  default test runner aliases with the actual default test runner constructor.
+  It also adds the default test runner to the projects missing a test runner."
+  [settings]
+  (let [project-settings (:projects settings)
+        enriched-projects (reduce enrich-test-settings
+                                  {}
+                                  project-settings)]
+    (assoc settings :projects enriched-projects)))

--- a/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
+++ b/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
@@ -37,3 +37,54 @@
                      "helpers"        {:alias "h"
                                        :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
          (settings/enrich-settings {:projects {"helpers" {:alias "h"}}} projects))))
+
+(deftest enrich-settings--a-set-of-projects-with-incomplete-project-mapping-and-with-empty-test-runner-config--returns-dev-and-undefined-mappings
+  (is (= {:projects {"backend-system" {:alias "?4"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "h"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
+         (settings/enrich-settings {:projects {"helpers" {:alias "h"
+                                                          :test {:create-test-runner []}}}}
+                                   projects))))
+
+(deftest enrich-settings--a-set-of-projects-with-incomplete-project-mapping-and-with-empty-test-config--returns-dev-and-undefined-mappings
+  (is (= {:projects {"backend-system" {:alias "?4"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "h"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
+         (settings/enrich-settings {:projects {"helpers" {:alias "h"
+                                                          :test {}}}}
+                                   projects))))
+
+(deftest enrich-settings--a-set-of-projects-with-incomplete-project-mapping-and-with-test-runner--returns-dev-and-undefined-mappings
+  (is (= {:projects {"backend-system" {:alias "?4"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "h"
+                                       :test  {:create-test-runner [:default]}}}}
+         (settings/enrich-settings {:projects {"helpers" {:alias "h"
+                                                          :test {:create-test-runner [:default]}}}}
+                                   projects))))

--- a/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
+++ b/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
@@ -84,7 +84,30 @@
                      "development"    {:alias "dev"
                                        :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
                      "helpers"        {:alias "h"
-                                       :test  {:create-test-runner [:default]}}}}
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
          (settings/enrich-settings {:projects {"helpers" {:alias "h"
                                                           :test {:create-test-runner [:default]}}}}
+                                   projects))))
+
+(deftest enrich-settings--a-set-of-projects-with-default-nil-and-non-vector-with-test-runner-config--returns-dev-undefined-mappings-and-correct-test-runners
+  (is (= {:projects {"backend-system" {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create
+                                                                    'se.example.create
+                                                                    'polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "clj"
+                                       :test  {:create-test-runner ['se.example/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "h"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
+         (settings/enrich-settings {:projects {"helpers" {:alias "h"
+                                                          :test {:create-test-runner [:default]}}
+                                               "development" {:test {:create-test-runner nil}}
+                                               "clojure" {:alias "clj"
+                                                          :test {:create-test-runner 'se.example/create}}
+                                               "car" {:test {:create-test-runner [:default 'se.example.create nil]}}}}
                                    projects))))

--- a/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
+++ b/components/workspace/test/polylith/clj/core/workspace/settings_test.clj
@@ -9,19 +9,31 @@
                {:name "helpers"}])
 
 (deftest enrich-settings--a-set-of-projects-without-project-mapping--returns-dev-and-undefined-mappings
-  (is (= {:projects {"backend-system" {:alias "?4"}
-                     "banking-system" {:alias "?2"}
-                     "car"            {:alias "?3"}
-                     "clojure"        {:alias "?1"}
-                     "development"    {:alias "dev"}
-                     "helpers"        {:alias "?5"}}}
+  (is (= {:projects {"backend-system" {:alias "?4"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "?5"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
          (settings/enrich-settings nil projects))))
 
 (deftest enrich-settings--a-set-of-projects-with-incomplete-project-mapping--returns-dev-and-undefined-mappings
-  (is (= {:projects {"backend-system" {:alias "?4"}
-                     "banking-system" {:alias "?2"}
-                     "car"            {:alias "?3"}
-                     "clojure"        {:alias "?1"}
-                     "development"    {:alias "dev"}
-                     "helpers"        {:alias "h"}}}
+  (is (= {:projects {"backend-system" {:alias "?4"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "banking-system" {:alias "?2"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "car"            {:alias "?3"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "clojure"        {:alias "?1"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "development"    {:alias "dev"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}
+                     "helpers"        {:alias "h"
+                                       :test  {:create-test-runner ['polylith.clj.core.clojure-test-test-runner.interface/create]}}}}
          (settings/enrich-settings {:projects {"helpers" {:alias "h"}}} projects))))

--- a/deps.edn
+++ b/deps.edn
@@ -61,6 +61,7 @@
                                  "components/path-finder/test"
                                  "components/shell/test"
                                  "components/test-runner-contract/test"
+                                 "components/test-runner-orchestrator/test"
                                  "components/user-input/test"
                                  "components/util/test"
                                  "components/validator/test"

--- a/projects/poly/test/project/poly/workspace_test.clj
+++ b/projects/poly/test/project/poly/workspace_test.clj
@@ -49,7 +49,7 @@
           "  tap                       tap *                        ---  s--    s--"
           "  test-helper               test-helper *                ---  -tx    s--"
           "  test-runner-contract      test-runner-contract *       s--  stx    st-"
-          "  test-runner-orchestrator  test-runner-orchestrator *   ---  s--    s--"
+          "  test-runner-orchestrator  test-runner-orchestrator *   ---  stx    st-"
           "  text-table                text-table *                 s--  s--    s--"
           "  user-config               user-config *                s--  s--    s--"
           "  user-input                user-input *                 s--  stx    st-"
@@ -423,7 +423,15 @@
           "test-runner-contract" {:src {:direct ["util"]}, :test {:direct ["util"]}},
           "test-runner-orchestrator" {:src {:direct ["common" "deps" "test-runner-contract" "util" "validator"],
                                             :indirect ["file" "path-finder" "text-table" "user-config"]},
-                                      :test {}},
+                                      :test {:direct   ["common"
+                                                        "deps"
+                                                        "test-runner-contract"
+                                                        "util"
+                                                        "validator"]
+                                             :indirect ["file"
+                                                        "path-finder"
+                                                        "text-table"
+                                                        "user-config"]}},
           "text-table" {:src {:direct ["util"]}, :test {}},
           "user-config" {:src {:direct ["file" "util"]}, :test {}},
           "user-input" {:src {:direct ["util"]}, :test {:direct ["util"]}},
@@ -530,6 +538,7 @@
           "components/test-helper/resources"
           "components/test-helper/src"
           "components/test-runner-contract/test"
+          "components/test-runner-orchestrator/test"
           "components/user-input/test"
           "components/util/test"
           "components/validator/test"
@@ -566,6 +575,7 @@
                  "puget.printer"
                  "zprint.core"]
           :test ["clojure.java.shell"
+                 "clojure.lang"
                  "clojure.string"
                  "clojure.test"
                  "malli.core"


### PR DESCRIPTION
Another stab at the issue #260 

This PR aimed to develop a cleaner solution with fewer changes to the existing code. It is a result of my discussion with @tengstrand and is heavily inspired by @seancorfield's PR #262. 

See [seancorfield/polylith-external-test-runner](https://github.com/seancorfield/polylith-external-test-runner) as an example of an external test runner.

There is no documentation about custom test runners, except the doc string in the `test-runner-contract` interface. It would be nice to add a new page to the poly documentation and explain how to develop custom in-process and external test runners.

Resolves #260, resolves #252, resolves #253
Also closes #262 