### PR TITLE
HotFix: Pass enriched-settings to the validator

### DIFF
--- a/components/workspace/src/polylith/clj/core/workspace/core.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/core.clj
@@ -38,7 +38,7 @@
         brick->lib-imports (brick->lib-imports enriched-bricks)
         enriched-settings (s/enrich-settings settings projects)
         enriched-projects (vec (sort-by project-sorter (mapv #(project/enrich-project % enriched-components enriched-bases suffixed-top-ns brick->loc brick->lib-imports paths enriched-settings) projects)))
-        messages (validator/validate-ws suffixed-top-ns settings paths interface-names interfaces enriched-components enriched-bases enriched-projects interface-ns user-input color-mode)]
+        messages (validator/validate-ws suffixed-top-ns enriched-settings paths interface-names interfaces enriched-components enriched-bases enriched-projects interface-ns user-input color-mode)]
     (assoc workspace :name ws-name
                      :settings enriched-settings
                      :interfaces interfaces


### PR DESCRIPTION
This PR addresses issue #265. The validator expects to have `enriched-settings`, and we mistakenly passed the original settings. This was working before we merged #263 since we did the settings enrichment in the `workspace-clj` component rather than in the `workspace` component.

Closes #265 