### PR TITLE
deps.edn: :build alias requires clojure.tools.deps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -80,7 +80,8 @@
             :migrator {:main-opts  ["-m" "polylith.clj.core.migrator-cli.core"]
                        :extra-deps {polylith/clj-poly-migrator {:local/root "projects/poly-migrator"}}}
 
-            :build {:deps {io.github.seancorfield/build-clj
+            :build {:deps {org.clojure/tools.deps {:mvn/version "0.16.1264"}
+                           io.github.seancorfield/build-clj
                            {:git/tag "v0.8.3" :git/sha "7ac1f8d"}
                            poly/version {:local/root "components/version"}}
                     :paths ["build/resources"]


### PR DESCRIPTION
Hello! I was running a debug build of polylith to diagnose some obscure problems with our CI, when I discovered this issue. The build alias requires clojure.tools.deps, otherwise it crashes as invoked from ./build.sh:

    $ clojure -T:build uberjar :project poly
    Execution error (FileNotFoundException) at build/eval216$loading (build.clj:1).
    Could not locate clojure/tools/deps__init.class, clojure/tools/deps.clj or clojure/tools/deps.cljc on classpath.

Signed-off-by: Ryan Sundberg <ryan@patch.tech>