### PR TITLE
Don't commit sub workspace in existing repo.

### DIFF
--- a/components/creator/src/polylith/clj/core/creator/workspace.clj
+++ b/components/creator/src/polylith/clj/core/creator/workspace.clj
@@ -137,5 +137,6 @@
       (and create-ws-dir?
            (file/exists ws-dir)) (println (str "  Workspace '" ws-name "' already exists."))
       (and (not create-ws-dir?)
-           (not git-repo?)) (println "  Current directory must be a git repo.")
+           (not git-repo?)) (println "  Current directory must be a git repo. Leave out :commit and try again.")
+      (and commit? git-repo?) (println "  Can't commit a workspace inside an existing git repo.")
       :else (create-ws ws-dir ws-name top-ns create-ws-dir? git-repo? insert-sha? sha branch git-add? commit?))))

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -5,13 +5,13 @@
 (def major 0)
 (def minor 2)
 (def patch 18)
-(def revision "issue259-12")
+(def revision "issue290-01")
 (def name (str major "." minor "." patch
                (if (str/blank? revision)
                  ""
                  (str "-" revision))))
 
-(def date "2023-03-30")
+(def date "2023-03-31")
 
 (defn version
   ([ws-type]


### PR DESCRIPTION
Show error if trying to create and commit a workspace within an existing workspace.