### PR TITLE
Document public API only

### DIFF
--- a/bases/poly-cli/src/polylith/clj/core/poly_cli/api.clj
+++ b/bases/poly-cli/src/polylith/clj/core/poly_cli/api.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.poly-cli.api
+(ns ^:no-doc polylith.clj.core.poly-cli.api
   "A poly tool API for the Clojure CLI's -X and -T options."
   (:refer-clojure :exclude [test])
   (:require [clojure.string :as str]

--- a/bases/poly-cli/src/polylith/clj/core/poly_cli/core.clj
+++ b/bases/poly-cli/src/polylith/clj/core/poly_cli/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.poly-cli.core
+(ns ^:no-doc polylith.clj.core.poly-cli.core
   (:require [polylith.clj.core.command.interface :as command]
             [polylith.clj.core.util.interface.exception :as ex]
             [polylith.clj.core.user-input.interface :as user-input])

--- a/components/antq/src/polylith/clj/core/antq/core.clj
+++ b/components/antq/src/polylith/clj/core/antq/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.antq.core
+(ns ^:no-doc polylith.clj.core.antq.core
   (:require [antq.api :as antq]
             [polylith.clj.core.common.interface :as common]))
 

--- a/components/antq/src/polylith/clj/core/antq/ifc.clj
+++ b/components/antq/src/polylith/clj/core/antq/ifc.clj
@@ -1,5 +1,5 @@
 ;; This interface has the name ifc, just to check that it's allowed!
-(ns polylith.clj.core.antq.ifc
+(ns ^:no-doc polylith.clj.core.antq.ifc
   (:require [polylith.clj.core.antq.core :as core]))
 
 (defn library->latest-version [configs]

--- a/components/api/src/polylith/clj/core/api/core.clj
+++ b/components/api/src/polylith/clj/core/api/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.api.core
+(ns ^:no-doc polylith.clj.core.api.core
   (:require [clojure.string :as str]
             [polylith.clj.core.change.interface :as change]
             [polylith.clj.core.user-input.interface :as user-input]

--- a/components/change/src/polylith/clj/core/change/bricks_to_test.clj
+++ b/components/change/src/polylith/clj/core/change/bricks_to_test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.bricks-to-test
+(ns ^:no-doc polylith.clj.core.change.bricks-to-test
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]))
 

--- a/components/change/src/polylith/clj/core/change/core.clj
+++ b/components/change/src/polylith/clj/core/change/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.core
+(ns ^:no-doc polylith.clj.core.change.core
   (:require [clojure.set :as set]
             [polylith.clj.core.change.entity :as entity]
             [polylith.clj.core.change.indirect :as indirect]

--- a/components/change/src/polylith/clj/core/change/entity.clj
+++ b/components/change/src/polylith/clj/core/change/entity.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.entity
+(ns ^:no-doc polylith.clj.core.change.entity
   (:require [polylith.clj.core.path-finder.interface.criterias :as c]
             [polylith.clj.core.path-finder.interface.select :as select]
             [polylith.clj.core.path-finder.interface.extract :as extract]))

--- a/components/change/src/polylith/clj/core/change/indirect.clj
+++ b/components/change/src/polylith/clj/core/change/indirect.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.indirect
+(ns ^:no-doc polylith.clj.core.change.indirect
   (:require [clojure.set :as set]))
 
 (defn brick-source-indirect-change [brick {:keys [direct indirect]} changed-bricks]

--- a/components/change/src/polylith/clj/core/change/interface.clj
+++ b/components/change/src/polylith/clj/core/change/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.interface
+(ns ^:no-doc polylith.clj.core.change.interface
   (:require [polylith.clj.core.change.core :as core]))
 
 (defn with-changes [workspace]

--- a/components/change/src/polylith/clj/core/change/project.clj
+++ b/components/change/src/polylith/clj/core/change/project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.project
+(ns ^:no-doc polylith.clj.core.change.project
   (:require [clojure.set :as set]))
 
 (defn changed-project [{:keys [name component-names base-names]} changed-bricks]

--- a/components/change/src/polylith/clj/core/change/projects_to_test.clj
+++ b/components/change/src/polylith/clj/core/change/projects_to_test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.change.projects-to-test
+(ns ^:no-doc polylith.clj.core.change.projects-to-test
   (:require [clojure.set :as set]
             [polylith.clj.core.path-finder.interface.criterias :as c]
             [polylith.clj.core.path-finder.interface.select :as select]

--- a/components/clojure-test-test-runner/src/polylith/clj/core/clojure_test_test_runner/core.clj
+++ b/components/clojure-test-test-runner/src/polylith/clj/core/clojure_test_test_runner/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.clojure-test-test-runner.core
+(ns ^:no-doc polylith.clj.core.clojure-test-test-runner.core
   (:require [clojure.string :as str]
             [polylith.clj.core.test-runner-contract.interface :as test-runner-contract]
             [polylith.clj.core.util.interface.color :as color]

--- a/components/clojure-test-test-runner/src/polylith/clj/core/clojure_test_test_runner/interface.clj
+++ b/components/clojure-test-test-runner/src/polylith/clj/core/clojure_test_test_runner/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.clojure-test-test-runner.interface
+(ns ^:no-doc polylith.clj.core.clojure-test-test-runner.interface
   (:require [polylith.clj.core.clojure-test-test-runner.core :as core]))
 
 (defn create [opts]

--- a/components/command/src/polylith/clj/core/command/cmd_validator/core.clj
+++ b/components/command/src/polylith/clj/core/command/cmd_validator/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.cmd-validator.core
+(ns ^:no-doc polylith.clj.core.command.cmd-validator.core
   (:require [polylith.clj.core.command.cmd-validator.create :as create]
             [polylith.clj.core.command.cmd-validator.profile :as profile]
             [polylith.clj.core.command.cmd-validator.project :as project]

--- a/components/command/src/polylith/clj/core/command/cmd_validator/create.clj
+++ b/components/command/src/polylith/clj/core/command/cmd_validator/create.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.cmd-validator.create
+(ns ^:no-doc polylith.clj.core.command.cmd-validator.create
   (:require [clojure.string :as str]
             [polylith.clj.core.command.message :as command]
             [polylith.clj.core.common.interface :as common]

--- a/components/command/src/polylith/clj/core/command/cmd_validator/executable.clj
+++ b/components/command/src/polylith/clj/core/command/cmd_validator/executable.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.cmd-validator.executable
+(ns ^:no-doc polylith.clj.core.command.cmd-validator.executable
   (:require [polylith.clj.core.command.message :as message]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.file.interface :as file]))

--- a/components/command/src/polylith/clj/core/command/cmd_validator/profile.clj
+++ b/components/command/src/polylith/clj/core/command/cmd_validator/profile.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.cmd-validator.profile
+(ns ^:no-doc polylith.clj.core.command.cmd-validator.profile
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/command/src/polylith/clj/core/command/cmd_validator/project.clj
+++ b/components/command/src/polylith/clj/core/command/cmd_validator/project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.cmd-validator.project
+(ns ^:no-doc polylith.clj.core.command.cmd-validator.project
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/command/src/polylith/clj/core/command/core.clj
+++ b/components/command/src/polylith/clj/core/command/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.core
+(ns ^:no-doc polylith.clj.core.command.core
   (:require [polylith.clj.core.change.interface :as change]
             [polylith.clj.core.command.cmd-validator.core :as cmd-validator]
             [polylith.clj.core.command.create :as create]

--- a/components/command/src/polylith/clj/core/command/create.clj
+++ b/components/command/src/polylith/clj/core/command/create.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.create
+(ns ^:no-doc polylith.clj.core.command.create
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.creator.interface :as creator]))
 

--- a/components/command/src/polylith/clj/core/command/dependencies.clj
+++ b/components/command/src/polylith/clj/core/command/dependencies.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.dependencies
+(ns ^:no-doc polylith.clj.core.command.dependencies
   (:require [polylith.clj.core.deps.interface :as deps]
             [polylith.clj.core.common.interface :as common]))
 

--- a/components/command/src/polylith/clj/core/command/exit_code.clj
+++ b/components/command/src/polylith/clj/core/command/exit_code.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.exit-code)
+(ns ^:no-doc polylith.clj.core.command.exit-code)
 
 (defn code [cmd {:keys [config-error messages]} test-ok?]
   (if config-error

--- a/components/command/src/polylith/clj/core/command/info.clj
+++ b/components/command/src/polylith/clj/core/command/info.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.info
+(ns ^:no-doc polylith.clj.core.command.info
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.workspace.interface :as ws]))
 

--- a/components/command/src/polylith/clj/core/command/interface.clj
+++ b/components/command/src/polylith/clj/core/command/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.interface
+(ns ^:no-doc polylith.clj.core.command.interface
   (:require [polylith.clj.core.command.core :as core]))
 
 (defn execute-command [user-input]

--- a/components/command/src/polylith/clj/core/command/message.clj
+++ b/components/command/src/polylith/clj/core/command/message.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.message)
+(ns ^:no-doc polylith.clj.core.command.message)
 
 (defn cant-be-executed-outside-ws-message [cmd]
   (if (= "test" cmd)

--- a/components/command/src/polylith/clj/core/command/test.clj
+++ b/components/command/src/polylith/clj/core/command/test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.test
+(ns ^:no-doc polylith.clj.core.command.test
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.test-runner-orchestrator.interface :as test-runner-orchestrator]))
 

--- a/components/command/src/polylith/clj/core/command/user_config.clj
+++ b/components/command/src/polylith/clj/core/command/user_config.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.command.user-config
+(ns ^:no-doc polylith.clj.core.command.user-config
   (:require [clojure.java.io :as io]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.user-config.interface :as user-config]

--- a/components/common/src/polylith/clj/core/common/class_loader.clj
+++ b/components/common/src/polylith/clj/core/common/class_loader.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.class-loader
+(ns ^:no-doc polylith.clj.core.common.class-loader
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [polylith.clj.core.util.interface.color :as color])

--- a/components/common/src/polylith/clj/core/common/core.clj
+++ b/components/common/src/polylith/clj/core/common/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.core
+(ns ^:no-doc polylith.clj.core.common.core
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]

--- a/components/common/src/polylith/clj/core/common/file_output.clj
+++ b/components/common/src/polylith/clj/core/common/file_output.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.file-output
+(ns ^:no-doc polylith.clj.core.common.file-output
   (:require [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.image-creator.interface :as image-creator]
             [polylith.clj.core.text-table.interface :as text-table]))

--- a/components/common/src/polylith/clj/core/common/interface.clj
+++ b/components/common/src/polylith/clj/core/common/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.interface
+(ns ^:no-doc polylith.clj.core.common.interface
   (:require [polylith.clj.core.common.class-loader :as class-loader]
             [polylith.clj.core.common.core :as core]
             [polylith.clj.core.common.file-output :as file-output]

--- a/components/common/src/polylith/clj/core/common/interface/config.clj
+++ b/components/common/src/polylith/clj/core/common/interface/config.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.interface.config)
+(ns ^:no-doc polylith.clj.core.common.interface.config)
 
 (defn src-paths [config]
   (-> config :paths))

--- a/components/common/src/polylith/clj/core/common/ns_extractor.clj
+++ b/components/common/src/polylith/clj/core/common/ns_extractor.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.ns-extractor
+(ns ^:no-doc polylith.clj.core.common.ns-extractor
   (:require [clojure.string :as str]))
 
 (defn entity-imports [{:keys [namespaces]} sources]

--- a/components/common/src/polylith/clj/core/common/validate_args.clj
+++ b/components/common/src/polylith/clj/core/common/validate_args.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.common.validate-args
+(ns ^:no-doc polylith.clj.core.common.validate-args
   (:require [clojure.string :as str]))
 
 (defn not-profile-or-empty? [arg]

--- a/components/config-reader/src/polylith/clj/core/config_reader/check_file.clj
+++ b/components/config-reader/src/polylith/clj/core/config_reader/check_file.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.config-reader.check-file
+(ns ^:no-doc polylith.clj.core.config-reader.check-file
   (:require [polylith.clj.core.file.interface :as file]))
 
 (defn file-exists? [filename]

--- a/components/config-reader/src/polylith/clj/core/config_reader/config_reader.clj
+++ b/components/config-reader/src/polylith/clj/core/config_reader/config_reader.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.config-reader.config-reader
+(ns ^:no-doc polylith.clj.core.config-reader.config-reader
   (:require [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.config-reader.deps-reader :as deps-reader]
             [polylith.clj.core.validator.interface :as validator]))

--- a/components/config-reader/src/polylith/clj/core/config_reader/deps_reader.clj
+++ b/components/config-reader/src/polylith/clj/core/config_reader/deps_reader.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.config-reader.deps-reader
+(ns ^:no-doc polylith.clj.core.config-reader.deps-reader
   (:require [clojure.java.io :as io]
             [clojure.edn :as edn])
   (:import (java.io IOException)))

--- a/components/config-reader/src/polylith/clj/core/config_reader/interface.clj
+++ b/components/config-reader/src/polylith/clj/core/config_reader/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.config-reader.interface
+(ns ^:no-doc polylith.clj.core.config-reader.interface
   (:require [polylith.clj.core.config-reader.check-file :as check-file]
             [polylith.clj.core.config-reader.config-reader :as config-reader]
             [polylith.clj.core.config-reader.deps-reader :as deps-reader]

--- a/components/config-reader/src/polylith/clj/core/config_reader/ws_root.clj
+++ b/components/config-reader/src/polylith/clj/core/config_reader/ws_root.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.config-reader.ws-root
+(ns ^:no-doc polylith.clj.core.config-reader.ws-root
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.config-reader.config-reader :as config-reader]

--- a/components/creator/src/polylith/clj/core/creator/base.clj
+++ b/components/creator/src/polylith/clj/core/creator/base.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.base
+(ns ^:no-doc polylith.clj.core.creator.base
   (:require [polylith.clj.core.creator.brick :as brick]))
 
 (defn create-base [ws-dir settings base-name is-git-add]

--- a/components/creator/src/polylith/clj/core/creator/brick.clj
+++ b/components/creator/src/polylith/clj/core/creator/brick.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.brick
+(ns ^:no-doc polylith.clj.core.creator.brick
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.git.interface :as git]

--- a/components/creator/src/polylith/clj/core/creator/component.clj
+++ b/components/creator/src/polylith/clj/core/creator/component.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.component
+(ns ^:no-doc polylith.clj.core.creator.component
   (:require [polylith.clj.core.creator.brick :as brick]))
 
 (defn create-component [ws-dir settings component-name interface-name is-git-add]

--- a/components/creator/src/polylith/clj/core/creator/interface.clj
+++ b/components/creator/src/polylith/clj/core/creator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.interface
+(ns ^:no-doc polylith.clj.core.creator.interface
   (:require [polylith.clj.core.creator.base :as base]
             [polylith.clj.core.creator.component :as component]
             [polylith.clj.core.creator.workspace :as workspace]

--- a/components/creator/src/polylith/clj/core/creator/project.clj
+++ b/components/creator/src/polylith/clj/core/creator/project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.project
+(ns ^:no-doc polylith.clj.core.creator.project
   (:require [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.common.interface :as common]

--- a/components/creator/src/polylith/clj/core/creator/shared.clj
+++ b/components/creator/src/polylith/clj/core/creator/shared.clj
@@ -1,3 +1,3 @@
-(ns polylith.clj.core.creator.shared)
+(ns ^:no-doc polylith.clj.core.creator.shared)
 
 (def clojure-ver "1.11.1")

--- a/components/creator/src/polylith/clj/core/creator/workspace.clj
+++ b/components/creator/src/polylith/clj/core/creator/workspace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.creator.workspace
+(ns ^:no-doc polylith.clj.core.creator.workspace
   (:require [clojure.string :as str]
             [polylith.clj.core.creator.shared :as shared]
             [polylith.clj.core.file.interface :as file]

--- a/components/deps/src/polylith/clj/core/deps/base_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/base_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.base-deps
+(ns ^:no-doc polylith.clj.core.deps.base-deps
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]))
 

--- a/components/deps/src/polylith/clj/core/deps/brick_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/brick_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.brick-deps
+(ns ^:no-doc polylith.clj.core.deps.brick-deps
   (:require [clojure.set :as set]))
 
 (defn suffixed-name [name test?]

--- a/components/deps/src/polylith/clj/core/deps/interface.clj
+++ b/components/deps/src/polylith/clj/core/deps/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.interface
+(ns ^:no-doc polylith.clj.core.deps.interface
   (:require [polylith.clj.core.deps.base-deps :as base-deps]
             [polylith.clj.core.deps.interface-deps :as ifc-deps]
             [polylith.clj.core.deps.lib-deps :as lib-deps]

--- a/components/deps/src/polylith/clj/core/deps/interface_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/interface_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.interface-deps
+(ns ^:no-doc polylith.clj.core.deps.interface-deps
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]))
 

--- a/components/deps/src/polylith/clj/core/deps/lib_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/lib_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.lib-deps
+(ns ^:no-doc polylith.clj.core.deps.lib-deps
   (:require [clojure.tools.deps :as tools-deps]
             [polylith.clj.core.user-config.interface :as user-config]))
 

--- a/components/deps/src/polylith/clj/core/deps/project_brick_deps.clj
+++ b/components/deps/src/polylith/clj/core/deps/project_brick_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.project-brick-deps
+(ns ^:no-doc polylith.clj.core.deps.project-brick-deps
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]))

--- a/components/deps/src/polylith/clj/core/deps/text_table/brick_deps_table.clj
+++ b/components/deps/src/polylith/clj/core/deps/text_table/brick_deps_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.text-table.brick-deps-table
+(ns ^:no-doc polylith.clj.core.deps.text-table.brick-deps-table
   (:require [polylith.clj.core.deps.text-table.shared :as shared]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.text-table.interface :as text-table]))

--- a/components/deps/src/polylith/clj/core/deps/text_table/brick_project_deps_table.clj
+++ b/components/deps/src/polylith/clj/core/deps/text_table/brick_project_deps_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.text-table.brick-project-deps-table
+(ns ^:no-doc polylith.clj.core.deps.text-table.brick-project-deps-table
   (:require [polylith.clj.core.deps.text-table.shared :as shared]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.text-table.interface :as text-table]

--- a/components/deps/src/polylith/clj/core/deps/text_table/shared.clj
+++ b/components/deps/src/polylith/clj/core/deps/text_table/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.text-table.shared
+(ns ^:no-doc polylith.clj.core.deps.text-table.shared
   (:require [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.text-table.interface :as text-table]))
 

--- a/components/deps/src/polylith/clj/core/deps/text_table/workspace_deps_table.clj
+++ b/components/deps/src/polylith/clj/core/deps/text_table/workspace_deps_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.text-table.workspace-deps-table
+(ns ^:no-doc polylith.clj.core.deps.text-table.workspace-deps-table
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.text-table.interface :as text-table]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/deps/src/polylith/clj/core/deps/text_table/workspace_project_deps_table.clj
+++ b/components/deps/src/polylith/clj/core/deps/text_table/workspace_project_deps_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.deps.text-table.workspace-project-deps-table
+(ns ^:no-doc polylith.clj.core.deps.text-table.workspace-project-deps-table
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.text-table.interface :as text-table]))

--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.file.core
+(ns ^:no-doc polylith.clj.core.file.core
   (:require [clojure.java.io :as io]
             [clojure.pprint :as pp]
             [clojure.string :as str]

--- a/components/file/src/polylith/clj/core/file/interface.clj
+++ b/components/file/src/polylith/clj/core/file/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.file.interface
+(ns ^:no-doc polylith.clj.core.file.interface
   (:require [me.raynes.fs :as fs]
             [polylith.clj.core.file.core :as core])
   (:import (java.io File)))

--- a/components/git/src/polylith/clj/core/git/core.clj
+++ b/components/git/src/polylith/clj/core/git/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.git.core
+(ns ^:no-doc polylith.clj.core.git.core
   (:require [clojure.string :as str]
             [polylith.clj.core.git.tag :as tag]
             [polylith.clj.core.sh.interface :as sh]))

--- a/components/git/src/polylith/clj/core/git/interface.clj
+++ b/components/git/src/polylith/clj/core/git/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.git.interface
+(ns ^:no-doc polylith.clj.core.git.interface
   (:require [polylith.clj.core.git.core :as core]
             [polylith.clj.core.git.tag :as tag]))
 

--- a/components/git/src/polylith/clj/core/git/tag.clj
+++ b/components/git/src/polylith/clj/core/git/tag.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.git.tag
+(ns ^:no-doc polylith.clj.core.git.tag
   (:require [clojure.string :as str]
             [polylith.clj.core.sh.interface :as sh]
             [polylith.clj.core.util.interface.str :as str-util]))

--- a/components/help/src/polylith/clj/core/help/check.clj
+++ b/components/help/src/polylith/clj/core/help/check.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.check
+(ns ^:no-doc polylith.clj.core.help.check
      (:require [polylith.clj.core.help.shared :as s]
                [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/help/src/polylith/clj/core/help/core.clj
+++ b/components/help/src/polylith/clj/core/help/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.core
+(ns ^:no-doc polylith.clj.core.help.core
   (:require [polylith.clj.core.help.check :as check]
             [polylith.clj.core.help.create :as create]
             [polylith.clj.core.help.deps :as deps]

--- a/components/help/src/polylith/clj/core/help/create.clj
+++ b/components/help/src/polylith/clj/core/help/create.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.create
+(ns ^:no-doc polylith.clj.core.help.create
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.help.shared :as s]
             [polylith.clj.core.help.create-component :as component]

--- a/components/help/src/polylith/clj/core/help/create_base.clj
+++ b/components/help/src/polylith/clj/core/help/create_base.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.create-base
+(ns ^:no-doc polylith.clj.core.help.create-base
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help-text [cm]

--- a/components/help/src/polylith/clj/core/help/create_component.clj
+++ b/components/help/src/polylith/clj/core/help/create_component.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.create-component
+(ns ^:no-doc polylith.clj.core.help.create-component
      (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help-text [cm]

--- a/components/help/src/polylith/clj/core/help/create_project.clj
+++ b/components/help/src/polylith/clj/core/help/create_project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.create-project
+(ns ^:no-doc polylith.clj.core.help.create-project
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help-text [cm]

--- a/components/help/src/polylith/clj/core/help/create_workspace.clj
+++ b/components/help/src/polylith/clj/core/help/create_workspace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.create-workspace
+(ns ^:no-doc polylith.clj.core.help.create-workspace
      (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help-text [cm]

--- a/components/help/src/polylith/clj/core/help/deps.clj
+++ b/components/help/src/polylith/clj/core/help/deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.deps
+(ns ^:no-doc polylith.clj.core.help.deps
   (:require [polylith.clj.core.help.shared :as s]
             [polylith.clj.core.help.deps-project :as deps-project]
             [polylith.clj.core.help.deps-brick :as deps-brick]

--- a/components/help/src/polylith/clj/core/help/deps_brick.clj
+++ b/components/help/src/polylith/clj/core/help/deps_brick.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.deps-brick
+(ns ^:no-doc polylith.clj.core.help.deps-brick
   (:require [polylith.clj.core.help.shared :as s]
             [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/help/src/polylith/clj/core/help/deps_brick_project.clj
+++ b/components/help/src/polylith/clj/core/help/deps_brick_project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.deps-brick-project
+(ns ^:no-doc polylith.clj.core.help.deps-brick-project
   (:require [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.help.shared :as s]))
 

--- a/components/help/src/polylith/clj/core/help/deps_project.clj
+++ b/components/help/src/polylith/clj/core/help/deps_project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.deps-project
+(ns ^:no-doc polylith.clj.core.help.deps-project
      (:require [polylith.clj.core.help.shared :as s]
                [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/help/src/polylith/clj/core/help/deps_workspace.clj
+++ b/components/help/src/polylith/clj/core/help/deps_workspace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.deps-workspace
+(ns ^:no-doc polylith.clj.core.help.deps-workspace
   (:require [polylith.clj.core.util.interface.color :as color]))
 
 (defn help [cm]

--- a/components/help/src/polylith/clj/core/help/diff.clj
+++ b/components/help/src/polylith/clj/core/help/diff.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.diff
+(ns ^:no-doc polylith.clj.core.help.diff
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help [cm]

--- a/components/help/src/polylith/clj/core/help/info.clj
+++ b/components/help/src/polylith/clj/core/help/info.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.info
+(ns ^:no-doc polylith.clj.core.help.info
      (:require [polylith.clj.core.help.shared :as s]
                [polylith.clj.core.help.shared :as shared]
                [polylith.clj.core.system.interface :as system]

--- a/components/help/src/polylith/clj/core/help/interface.clj
+++ b/components/help/src/polylith/clj/core/help/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.interface
+(ns ^:no-doc polylith.clj.core.help.interface
   (:require [polylith.clj.core.help.core :as core]))
 
 (defn print-help [cmd ent is-all is-show-project is-show-brick is-show-workspace toolsdeps1? fake-poly? color-mode]

--- a/components/help/src/polylith/clj/core/help/libs.clj
+++ b/components/help/src/polylith/clj/core/help/libs.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.libs
+(ns ^:no-doc polylith.clj.core.help.libs
      (:require [polylith.clj.core.help.shared :as s]
                [polylith.clj.core.system.interface :as system]
                [polylith.clj.core.util.interface.color :as color]))

--- a/components/help/src/polylith/clj/core/help/migrate.clj
+++ b/components/help/src/polylith/clj/core/help/migrate.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.migrate)
+(ns ^:no-doc polylith.clj.core.help.migrate)
 
 (defn help []
   (str "  Migrates a workspace to the latest version.\n"

--- a/components/help/src/polylith/clj/core/help/overview.clj
+++ b/components/help/src/polylith/clj/core/help/overview.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.overview
+(ns ^:no-doc polylith.clj.core.help.overview
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help-text [cm]

--- a/components/help/src/polylith/clj/core/help/shared.clj
+++ b/components/help/src/polylith/clj/core/help/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.shared
+(ns ^:no-doc polylith.clj.core.help.shared
   (:require [polylith.clj.core.util.interface.color :as color]
             [clojure.string :as str])
   (:refer-clojure :exclude [key]))

--- a/components/help/src/polylith/clj/core/help/shell.clj
+++ b/components/help/src/polylith/clj/core/help/shell.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.shell
+(ns ^:no-doc polylith.clj.core.help.shell
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help [cm]

--- a/components/help/src/polylith/clj/core/help/summary.clj
+++ b/components/help/src/polylith/clj/core/help/summary.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.summary
+(ns ^:no-doc polylith.clj.core.help.summary
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.help.shared :as s]

--- a/components/help/src/polylith/clj/core/help/switch_ws.clj
+++ b/components/help/src/polylith/clj/core/help/switch_ws.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.switch-ws
+(ns ^:no-doc polylith.clj.core.help.switch-ws
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help [cm]

--- a/components/help/src/polylith/clj/core/help/tap.clj
+++ b/components/help/src/polylith/clj/core/help/tap.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.tap
+(ns ^:no-doc polylith.clj.core.help.tap
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help [cm]

--- a/components/help/src/polylith/clj/core/help/test.clj
+++ b/components/help/src/polylith/clj/core/help/test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.test
+(ns ^:no-doc polylith.clj.core.help.test
   (:require [polylith.clj.core.help.shared :as s]
             [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/help/src/polylith/clj/core/help/version.clj
+++ b/components/help/src/polylith/clj/core/help/version.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.version
+(ns ^:no-doc polylith.clj.core.help.version
   (:require [polylith.clj.core.version.interface :as version]))
 
 (defn help []

--- a/components/help/src/polylith/clj/core/help/ws.clj
+++ b/components/help/src/polylith/clj/core/help/ws.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.help.ws
+(ns ^:no-doc polylith.clj.core.help.ws
   (:require [polylith.clj.core.help.shared :as s]))
 
 (defn help [cm]

--- a/components/image-creator-x/src/polylith/clj/core/image_creator/core.clj
+++ b/components/image-creator-x/src/polylith/clj/core/image_creator/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.image-creator.core
+(ns ^:no-doc polylith.clj.core.image-creator.core
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure2d.core :as c2d]

--- a/components/image-creator-x/src/polylith/clj/core/image_creator/interface.clj
+++ b/components/image-creator-x/src/polylith/clj/core/image_creator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.image-creator.interface
+(ns ^:no-doc polylith.clj.core.image-creator.interface
   (:require [polylith.clj.core.image-creator.core :as core]))
 
 (def font-width core/font-width) ;(c2d/char-width graphics \x)

--- a/components/image-creator/src/polylith/clj/core/image_creator/interface.clj
+++ b/components/image-creator/src/polylith/clj/core/image_creator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.image-creator.interface)
+(ns ^:no-doc polylith.clj.core.image-creator.interface)
 
 (def font-width 12)
 (def font-height 24)

--- a/components/lib/src/polylith/clj/core/lib/core.clj
+++ b/components/lib/src/polylith/clj/core/lib/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.core
+(ns ^:no-doc polylith.clj.core.lib.core
   (:require [polylith.clj.core.config-reader.interface :as config-reader]
             [polylith.clj.core.lib.maven-dep :as maven-dep]
             [polylith.clj.core.lib.size :as size]

--- a/components/lib/src/polylith/clj/core/lib/git_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/git_size.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.git-size
+(ns ^:no-doc polylith.clj.core.lib.git-size
   (:require [clojure.string :as str]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.util.interface :as util]))

--- a/components/lib/src/polylith/clj/core/lib/interface.clj
+++ b/components/lib/src/polylith/clj/core/lib/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.interface
+(ns ^:no-doc polylith.clj.core.lib.interface
   (:require [polylith.clj.core.lib.core :as core]
             [polylith.clj.core.lib.size :as size]
             [polylith.clj.core.lib.resolve-libs :as resolve-libs]

--- a/components/lib/src/polylith/clj/core/lib/local_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/local_size.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.local-size
+(ns ^:no-doc polylith.clj.core.lib.local-size
   (:require [polylith.clj.core.lib.version :as version]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.common.interface :as common]))

--- a/components/lib/src/polylith/clj/core/lib/maven_dep.clj
+++ b/components/lib/src/polylith/clj/core/lib/maven_dep.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.maven-dep
+(ns ^:no-doc polylith.clj.core.lib.maven-dep
   (:import [org.eclipse.aether.util.version GenericVersionScheme]))
 
 (defonce version-scheme (GenericVersionScheme.))

--- a/components/lib/src/polylith/clj/core/lib/mvn_size.clj
+++ b/components/lib/src/polylith/clj/core/lib/mvn_size.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.mvn-size
+(ns ^:no-doc polylith.clj.core.lib.mvn-size
   (:require [clojure.string :as str]
             [clojure.walk :as walk]
             [polylith.clj.core.file.interface :as file]

--- a/components/lib/src/polylith/clj/core/lib/ns_to_lib.clj
+++ b/components/lib/src/polylith/clj/core/lib/ns_to_lib.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.ns-to-lib
+(ns ^:no-doc polylith.clj.core.lib.ns-to-lib
   (:require [clojure.string :as str]
             [polylith.clj.core.lib.size :as size]
             [polylith.clj.core.util.interface :as util]

--- a/components/lib/src/polylith/clj/core/lib/resolve_libs.clj
+++ b/components/lib/src/polylith/clj/core/lib/resolve_libs.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.resolve-libs
+(ns ^:no-doc polylith.clj.core.lib.resolve-libs
   (:require [polylith.clj.core.lib.maven-dep :as maven-dep]))
 
 (defn latest [m [library version]]

--- a/components/lib/src/polylith/clj/core/lib/size.clj
+++ b/components/lib/src/polylith/clj/core/lib/size.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.size
+(ns ^:no-doc polylith.clj.core.lib.size
   (:require [polylith.clj.core.lib.git-size :as git-size]
             [polylith.clj.core.lib.mvn-size :as mvn-size]
             [polylith.clj.core.lib.local-size :as local-size]))

--- a/components/lib/src/polylith/clj/core/lib/text_table/lib_table.clj
+++ b/components/lib/src/polylith/clj/core/lib/text_table/lib_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.text-table.lib-table
+(ns ^:no-doc polylith.clj.core.lib.text-table.lib-table
   (:require [polylith.clj.core.antq.ifc :as antq]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.text-table.interface :as text-table]

--- a/components/lib/src/polylith/clj/core/lib/version.clj
+++ b/components/lib/src/polylith/clj/core/lib/version.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.lib.version
+(ns ^:no-doc polylith.clj.core.lib.version
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.str :as str-util]))
 

--- a/components/migrator/src/polylith/clj/core/migrator/brick_deps.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/brick_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.brick-deps
+(ns ^:no-doc polylith.clj.core.migrator.brick-deps
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.migrator.shared :as shared]))
 

--- a/components/migrator/src/polylith/clj/core/migrator/core.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.core
+(ns ^:no-doc polylith.clj.core.migrator.core
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.migrator.brick-deps :as brick-deps]
             [polylith.clj.core.migrator.project-deps :as project-deps]

--- a/components/migrator/src/polylith/clj/core/migrator/interface.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.interface
+(ns ^:no-doc polylith.clj.core.migrator.interface
   (:require [polylith.clj.core.migrator.core :as core]))
 
 (defn migrate [ws-dir workspace]

--- a/components/migrator/src/polylith/clj/core/migrator/project_deps.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/project_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.project-deps
+(ns ^:no-doc polylith.clj.core.migrator.project-deps
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.config-reader.interface :as config-reader]

--- a/components/migrator/src/polylith/clj/core/migrator/shared.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.shared
+(ns ^:no-doc polylith.clj.core.migrator.shared
   (:require [clojure.walk :as walk]
             [zprint.core :as zp])
   (:import (clojure.lang PersistentArrayMap)

--- a/components/migrator/src/polylith/clj/core/migrator/workspace_deps.clj
+++ b/components/migrator/src/polylith/clj/core/migrator/workspace_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.migrator.workspace-deps
+(ns ^:no-doc polylith.clj.core.migrator.workspace-deps
   (:require [polylith.clj.core.migrator.shared :as shared]))
 
 (defn create-config-file

--- a/components/overview/src/polylith/clj/core/overview/core.clj
+++ b/components/overview/src/polylith/clj/core/overview/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.overview.core
+(ns ^:no-doc polylith.clj.core.overview.core
   (:require [clojure.string :as str]
             [polylith.clj.core.change.interface :as change]
             [polylith.clj.core.common.interface :as common]

--- a/components/overview/src/polylith/clj/core/overview/interface.clj
+++ b/components/overview/src/polylith/clj/core/overview/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.overview.interface
+(ns ^:no-doc polylith.clj.core.overview.interface
   (:require [polylith.clj.core.overview.core :as core]))
 
 (defn print-table [workspace]

--- a/components/path-finder/src/polylith/clj/core/path_finder/interface.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.interface
+(ns ^:no-doc polylith.clj.core.path-finder.interface
   (:require [polylith.clj.core.path-finder.paths :as paths]))
 
 (defn paths [ws-dir projects profile-to-settings]

--- a/components/path-finder/src/polylith/clj/core/path_finder/interface/criterias.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/interface/criterias.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.interface.criterias
+(ns ^:no-doc polylith.clj.core.path-finder.interface.criterias
   (:require [clojure.string :as str]))
 
 (defn truthy [_]

--- a/components/path-finder/src/polylith/clj/core/path_finder/interface/extract.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/interface/extract.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.interface.extract
+(ns ^:no-doc polylith.clj.core.path-finder.interface.extract
   (:require [polylith.clj.core.path-finder.path-extractor :as path-extractor]
             [polylith.clj.core.path-finder.lib-dep-extractor :as lib-dep-extractor]))
 

--- a/components/path-finder/src/polylith/clj/core/path_finder/interface/select.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/interface/select.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.interface.select
+(ns ^:no-doc polylith.clj.core.path-finder.interface.select
   (:require [polylith.clj.core.path-finder.selector :as select]))
 
 (defn entries [path-entries & criterias]

--- a/components/path-finder/src/polylith/clj/core/path_finder/interface/status.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/interface/status.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.interface.status
+(ns ^:no-doc polylith.clj.core.path-finder.interface.status
   (:require [polylith.clj.core.path-finder.interface.criterias :as c]
             [polylith.clj.core.path-finder.status-calculator :as status-calculator]))
 

--- a/components/path-finder/src/polylith/clj/core/path_finder/lib_dep_extractor.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/lib_dep_extractor.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.lib-dep-extractor
+(ns ^:no-doc polylith.clj.core.path-finder.lib-dep-extractor
   (:require [polylith.clj.core.util.interface :as util]))
 
 (defn deps-entry [lib-dep profile? test?]

--- a/components/path-finder/src/polylith/clj/core/path_finder/path_extractor.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/path_extractor.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.path-extractor
+(ns ^:no-doc polylith.clj.core.path-finder.path-extractor
   (:require [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.str :as str-util]

--- a/components/path-finder/src/polylith/clj/core/path_finder/paths.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/paths.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.paths
+(ns ^:no-doc polylith.clj.core.path-finder.paths
   (:require [clojure.set :as set]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.path-finder.sources-on-disk :as sources]))

--- a/components/path-finder/src/polylith/clj/core/path_finder/profile_src_splitter.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/profile_src_splitter.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.profile-src-splitter
+(ns ^:no-doc polylith.clj.core.path-finder.profile-src-splitter
   (:require [clojure.string :as str]))
 
 (defn test-path? [path]

--- a/components/path-finder/src/polylith/clj/core/path_finder/selector.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/selector.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.selector
+(ns ^:no-doc polylith.clj.core.path-finder.selector
   (:require [polylith.clj.core.path-finder.interface.criterias :as criterias]))
 
 (defn entries [path-entries criterias]

--- a/components/path-finder/src/polylith/clj/core/path_finder/sources_on_disk.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/sources_on_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.sources-on-disk
+(ns ^:no-doc polylith.clj.core.path-finder.sources-on-disk
   (:require [polylith.clj.core.file.interface :as file]))
 
 (defn- entity-source-paths [ws-dir entity-type entity]

--- a/components/path-finder/src/polylith/clj/core/path_finder/status_calculator.clj
+++ b/components/path-finder/src/polylith/clj/core/path_finder/status_calculator.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.path-finder.status-calculator
+(ns ^:no-doc polylith.clj.core.path-finder.status-calculator
   (:require [polylith.clj.core.path-finder.interface.criterias :as c]))
 
 (defn status-flag [path-entries name flag & criterias]

--- a/components/sh/src/polylith/clj/core/sh/core.clj
+++ b/components/sh/src/polylith/clj/core/sh/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.sh.core
+(ns ^:no-doc polylith.clj.core.sh.core
   (:require [clojure.java.shell :as shell]))
 
 (defn execute [args]

--- a/components/sh/src/polylith/clj/core/sh/interface.clj
+++ b/components/sh/src/polylith/clj/core/sh/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.sh.interface
+(ns ^:no-doc polylith.clj.core.sh.interface
   (:require [polylith.clj.core.sh.core :as core]))
 
 (defn execute [& args]

--- a/components/shell/src/polylith/clj/core/shell/candidate/creators.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/creators.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.creators
+(ns ^:no-doc polylith.clj.core.shell.candidate.creators
   (:require [polylith.clj.core.util.interface.color :as color]))
 
 (defn with-val [candidate value]

--- a/components/shell/src/polylith/clj/core/shell/candidate/engine.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/engine.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.engine
+(ns ^:no-doc polylith.clj.core.shell.candidate.engine
   (:require [clojure.string :as str]
             [polylith.clj.core.shell.candidate.shared :as shared]
             [polylith.clj.core.shell.candidate.specification :as specification])

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/color_modes.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/color_modes.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.color-modes
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.color-modes
   (:require [clojure.set :as set]
             [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.shell.candidate.shared :as shared]))

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/file_explorer.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/file_explorer.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.file-explorer
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.file-explorer
   (:require [clojure.string :as str]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.shell.candidate.creators :as c]

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/remote_branches.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/remote_branches.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.remote-branches
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.remote-branches
   (:require [clojure.string :as str]
             [polylith.clj.core.sh.interface :as sh]
             [polylith.clj.core.shell.candidate.creators :as c]))

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_bricks.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_bricks.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-bricks
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-bricks
   (:require [clojure.set :as set]
             [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.shell.candidate.shared :as shared]))

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_deps_entities.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_deps_entities.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-deps-entities
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-deps-entities
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.shell.candidate.creators :as c]

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_explore.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_explore.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-explore
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-explore
   (:require [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.ws-explorer.interface :as ws-explorer]))
 

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_projects.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_projects.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-projects
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-projects
   (:require [clojure.set :as set]
             [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.shell.candidate.shared :as shared]))

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_projects_to_test.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_projects_to_test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-projects-to-test
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-projects-to-test
   (:require [clojure.set :as set]
             [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.shell.candidate.shared :as shared]))

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_tag_patterns.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/ws_tag_patterns.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.selector.ws-tag-patterns
+(ns ^:no-doc polylith.clj.core.shell.candidate.selector.ws-tag-patterns
   (:require [polylith.clj.core.shell.candidate.creators :as c]))
 
 (defn tag-keys [tag-pattern-key]

--- a/components/shell/src/polylith/clj/core/shell/candidate/shared.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.shared
+(ns ^:no-doc polylith.clj.core.shell.candidate.shared
   (:require [polylith.clj.core.util.interface.color :as color]))
 
 (defn show-compact? [view settings]

--- a/components/shell/src/polylith/clj/core/shell/candidate/specification.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/specification.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.candidate.specification
+(ns ^:no-doc polylith.clj.core.shell.candidate.specification
   [:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.shell.candidate.creators :as c]
             [polylith.clj.core.shell.candidate.selector.remote-branches :as remote-branches]

--- a/components/shell/src/polylith/clj/core/shell/core.clj
+++ b/components/shell/src/polylith/clj/core/shell/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.core
+(ns ^:no-doc polylith.clj.core.shell.core
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.shell.jline :as jline]

--- a/components/shell/src/polylith/clj/core/shell/interface.clj
+++ b/components/shell/src/polylith/clj/core/shell/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.interface
+(ns ^:no-doc polylith.clj.core.shell.interface
   (:require [polylith.clj.core.shell.core :as core]))
 
 (defn start

--- a/components/shell/src/polylith/clj/core/shell/jline.clj
+++ b/components/shell/src/polylith/clj/core/shell/jline.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.shell.jline
+(ns ^:no-doc polylith.clj.core.shell.jline
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.str :as str-util]
             [polylith.clj.core.shell.candidate.engine :as engine])

--- a/components/system-x/src/polylith/clj/core/system/interface.clj
+++ b/components/system-x/src/polylith/clj/core/system/interface.clj
@@ -1,3 +1,3 @@
-(ns polylith.clj.core.system.interface)
+(ns ^:no-doc polylith.clj.core.system.interface)
 
 (def extended? true)

--- a/components/system/src/polylith/clj/core/system/interface.clj
+++ b/components/system/src/polylith/clj/core/system/interface.clj
@@ -1,3 +1,3 @@
-(ns polylith.clj.core.system.interface)
+(ns ^:no-doc polylith.clj.core.system.interface)
 
 (def extended? false)

--- a/components/tap/src/polylith/clj/core/tap/core.clj
+++ b/components/tap/src/polylith/clj/core/tap/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.tap.core
+(ns ^:no-doc polylith.clj.core.tap.core
   (:require [clojure.string :as str]
             [portal.api :as portal]))
 

--- a/components/tap/src/polylith/clj/core/tap/interface.clj
+++ b/components/tap/src/polylith/clj/core/tap/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.tap.interface
+(ns ^:no-doc polylith.clj.core.tap.interface
   (:require [polylith.clj.core.tap.core :as core]))
 
 (defn execute [cmd]

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/initializers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/initializers.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-contract.initializers)
+(ns ^:no-doc polylith.clj.core.test-runner-contract.initializers)
 
 (defn ensure-var [candidate sym]
   (when-not (var? candidate)

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface.clj
@@ -4,47 +4,47 @@
   "Implement this protocol to supply a custom test runner.
 
   Runner options:
-  `is-verbose`      -> A boolean indicating if we are running in verbose mode
-                       or not. TestRunner can use this to print additional
+  - `is-verbose`       A boolean indicating if we are running in verbose mode
+                       or not. `TestRunner` can use this to print additional
                        information about the test run.
-  `color-mode`      -> The color-mode that the poly tool is currently running with.
-                       TestRunner is expected to respect the color mode.
-  `project`         -> A map containing the project information.
-  `all-paths`       -> A vector of all paths necessary to create a classpath for
+  - `color-mode`       The color-mode that the poly tool is currently running with.
+                       `TestRunner` is expected to respect the color mode.
+  - `project`          A map containing the project information.
+  - `all-paths`        A vector of all paths necessary to create a classpath for
                        running the tests in isolation within the context of the
                        current project.
-  `setup-fn`        -> An optional setup function for tests defined in the
+  - `setup-fn`         An optional setup function for tests defined in the
                        workspace config. The poly tool will run this function
                        before calling run-tests only if this is an in-process
-                       TestRunner. If this is an ExternalTestRunner, the external
-                       test runner should run the setup-fn.
-  `teardown-fn`     -> An optional teardown function for tests defined in the
+                       `TestRunner`. If this is an `ExternalTestRunner`, the external
+                       test runner should run the `setup-fn`.
+  - `teardown-fn`      An optional teardown function for tests defined in the
                        workspace config. The poly tool will run this function
                        after the run-tests function completes (exception or not),
-                       only if this is an in-process TestRunner. If this is an
-                       ExternalTestRunner, the external test runner should run
-                       the teardown-fn.
+                       only if this is an in-process `TestRunner`. If this is an
+                       `ExternalTestRunner`, the external test runner should run
+                       the `teardown-fn`.
 
-  Additional options for in-process TestRunner:
-  `class-loader`    -> The isolated classloader created from the `all-paths`.
+  Additional options for in-process `TestRunner`:
+  - `class-loader`     The isolated classloader created from the `all-paths`.
                        This classloader will be used to evaluate statements within
                        the project's context. Use this if you need more granular
                        access. `eval-in-project` should be sufficient for most
                        cases.
-  `eval-in-project` -> A function that takes a single form as its argument and
+  - `eval-in-project`  A function that takes a single form as its argument and
                        evaluates it within the project's classloader. It returns
                        the result of the evaluation. This is the primary interface
                        for running tests in the project's isolated context.
 
-  Additional options for ExternalTestRunner:
-  `process-ns`      -> The main namespace of the external test runner. This
+  Additional options for `ExternalTestRunner`:
+  - `process-ns`       The main namespace of the external test runner. This
                        namespace will be invoked as a Java subprocess.
 
   Usage:
-  Create a constructor function that returns an instance of TestRunner or
-  ExternalTestRunner:
+  Create a constructor function that returns an instance of `TestRunner` or
+  `ExternalTestRunner`:
 
-  ```
+  ```Clojure
   (defn create [{:keys [workspace project test-settings is-verbose color-mode changes]}]
     ...
 
@@ -62,46 +62,50 @@
       test-runner-contract/ExternalTestRunner
       (external-process-namespace [this] ...)))
   ```
-
   `workspace` passed to the constructor will contain `:user-input`, which
   can be used to receive additional parameters for runtime configuration.
 
-  Add your constructor function in the workspace.edn. To add a single global
+  Add your constructor function in the `workspace.edn`. To add a single global
   test runner, use the `:test` key:
 
+  ```Clojure
   {:test {:create-test-runner my.namespace/create}
-
    :projects {\"project-a\" {:alias \"a\"}
               \"project-b\" {:alias \"b\"}}}
+  ```
 
   To add a multiple global test runners, use the vector variant inside the
   `:test` key. The following example will add three test runners globally
   where the last one is the default test runner.
 
+  ```Clojure
   {:test {:create-test-runner [my.namespace/create se.example/create :default]}
-
    :projects {\"project-a\" {:alias \"a\"}
               \"project-b\" {:alias \"b\"}}}
+  ```
 
   To add a custom test runner for a specific project, use the `:test` key
   in the project configuration. You can also add multiple test runners with
   using the vector variant.
 
+  ```Clojure
   {:projects {\"project-a\" {:alias \"a\"
                              :test {:create-test-runner my.namespace/create}}
               \"project-b\" {:alias \"b\"
                              :test {:create-test-runner [my.namespace/create
                                                          :default]}}}}
+  ```
 
   Adding a test runner definition to a project will override the global test
-  runner. The project-a will use the global test runner, `my.namespace/create`
-  whereas project-b will use the default test runner.
+  runner. The `project-a` will use the global test runner, `my.namespace/create`
+  whereas `project-b` will use the default test runner.
 
+  ```Clojure
   {:test {:create-test-runner my.namespace/create}
-
    :projects {\"project-a\" {:alias \"a\"}
               \"project-b\" {:alias \"b\"
-                             :test {:create-test-runner :default}}}}"
+                             :test {:create-test-runner :default}}}}
+  ```"
 
   (test-runner-name [this]
     "Returns a printable name that the poly tool can print out for
@@ -130,7 +134,7 @@
 
   (external-process-namespace [this]
     "Returns a symbol or string identifying the main namespace of an external
-    test runner. If it returns nil (default), the test runner will be an
+    test runner. If it returns `nil` (default), the test runner will be an
     in-process test runner and the tests will run in an isolated classloader
     within the same process.
 

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/initializers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/initializers.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-contract.interface.initializers
+(ns ^:no-doc polylith.clj.core.test-runner-contract.interface.initializers
   (:require [polylith.clj.core.test-runner-contract.initializers :as core]))
 
 (defn ->constructor-var [create-test-runner-sym]

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/verifiers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/interface/verifiers.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-contract.interface.verifiers
+(ns ^:no-doc polylith.clj.core.test-runner-contract.interface.verifiers
   (:require [polylith.clj.core.test-runner-contract.verifiers :as core]))
 
 (defn valid-constructor-var? [candidate]

--- a/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/verifiers.clj
+++ b/components/test-runner-contract/src/polylith/clj/core/test_runner_contract/verifiers.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-contract.verifiers
+(ns ^:no-doc polylith.clj.core.test-runner-contract.verifiers
   (:require [polylith.clj.core.test-runner-contract.interface :as test-runner-contract]
             [polylith.clj.core.util.interface :as util]))
 

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-orchestrator.core
+(ns ^:no-doc polylith.clj.core.test-runner-orchestrator.core
   (:refer-clojure :exclude [test])
   (:require
    [clojure.set :as set]

--- a/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/interface.clj
+++ b/components/test-runner-orchestrator/src/polylith/clj/core/test_runner_orchestrator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.test-runner-orchestrator.interface
+(ns ^:no-doc polylith.clj.core.test-runner-orchestrator.interface
   (:require [polylith.clj.core.test-runner-orchestrator.core :as core]))
 
 (defn run [workspace is-verbose color-mode]

--- a/components/text-table/src/polylith/clj/core/text_table/cell.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/cell.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.cell
+(ns ^:no-doc polylith.clj.core.text-table.cell
   (:require [polylith.clj.core.util.interface.str :as str-util]))
 
 (defn cell [column row value color align orientation]

--- a/components/text-table/src/polylith/clj/core/text_table/core.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.core
+(ns ^:no-doc polylith.clj.core.text-table.core
   (:require [clojure.string :as str]
             [polylith.clj.core.text-table.flipper :as flipper]
             [polylith.clj.core.text-table.merger :as merger]

--- a/components/text-table/src/polylith/clj/core/text_table/flipper.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/flipper.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.flipper
+(ns ^:no-doc polylith.clj.core.text-table.flipper
   (:require [polylith.clj.core.util.interface.str :as str-util]
             [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/text-table/src/polylith/clj/core/text_table/interface.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.interface
+(ns ^:no-doc polylith.clj.core.text-table.interface
   (:require [polylith.clj.core.text-table.cell :as cell]
             [polylith.clj.core.text-table.core :as core]
             [polylith.clj.core.text-table.line :as line]

--- a/components/text-table/src/polylith/clj/core/text_table/line.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/line.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.line
+(ns ^:no-doc polylith.clj.core.text-table.line
   (:require [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.util.interface.str :as str-util]))
 

--- a/components/text-table/src/polylith/clj/core/text_table/merger.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/merger.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.merger)
+(ns ^:no-doc polylith.clj.core.text-table.merger)
 
 (defn key-row [{:keys [row column value align color orientation]}]
   [[row column] {:row row

--- a/components/text-table/src/polylith/clj/core/text_table/spaces.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/spaces.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.spaces)
+(ns ^:no-doc polylith.clj.core.text-table.spaces)
 
 (defn row-cell [row column value]
   {:row row

--- a/components/text-table/src/polylith/clj/core/text_table/table.clj
+++ b/components/text-table/src/polylith/clj/core/text_table/table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.text-table.table
+(ns ^:no-doc polylith.clj.core.text-table.table
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.color :as c]
             [polylith.clj.core.util.interface.str :as str-util]))

--- a/components/user-config/src/polylith/clj/core/user_config/core.clj
+++ b/components/user-config/src/polylith/clj/core/user_config/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.user-config.core
+(ns ^:no-doc polylith.clj.core.user-config.core
   (:require [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.util.interface.str :as str-util]))
 

--- a/components/user-config/src/polylith/clj/core/user_config/interface.clj
+++ b/components/user-config/src/polylith/clj/core/user_config/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.user-config.interface
+(ns ^:no-doc polylith.clj.core.user-config.interface
   (:require [polylith.clj.core.user-config.core :as core]))
 
 (defn home-dir []

--- a/components/user-input/src/polylith/clj/core/user_input/core.clj
+++ b/components/user-input/src/polylith/clj/core/user_input/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.user-input.core
+(ns ^:no-doc polylith.clj.core.user-input.core
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.user-input.params :as params]))

--- a/components/user-input/src/polylith/clj/core/user_input/interface.clj
+++ b/components/user-input/src/polylith/clj/core/user_input/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.user-input.interface
+(ns ^:no-doc polylith.clj.core.user-input.interface
   (:require [polylith.clj.core.user-input.core :as core]))
 
 (defn extract-params [args]

--- a/components/user-input/src/polylith/clj/core/user_input/params.clj
+++ b/components/user-input/src/polylith/clj/core/user_input/params.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.user-input.params
+(ns ^:no-doc polylith.clj.core.user-input.params
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.str :as str-util]))
 

--- a/components/util/src/polylith/clj/core/util/color_splitter.clj
+++ b/components/util/src/polylith/clj/core/util/color_splitter.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.color-splitter
+(ns ^:no-doc polylith.clj.core.util.color-splitter
   (:require [clojure.string :as str]
             [polylith.clj.core.util.colors :as c]))
 

--- a/components/util/src/polylith/clj/core/util/colorizer.clj
+++ b/components/util/src/polylith/clj/core/util/colorizer.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.colorizer
+(ns ^:no-doc polylith.clj.core.util.colorizer
   (:require [clojure.string :as str]
             [polylith.clj.core.util.colors :as c]))
 

--- a/components/util/src/polylith/clj/core/util/colors.clj
+++ b/components/util/src/polylith/clj/core/util/colors.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.colors)
+(ns ^:no-doc polylith.clj.core.util.colors)
 
 (def color-reset      "\u001B[0m")
 (def color-black      "\u001B[30m")

--- a/components/util/src/polylith/clj/core/util/core.clj
+++ b/components/util/src/polylith/clj/core/util/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.core)
+(ns ^:no-doc polylith.clj.core.util.core)
 
 (defn find-first [predicate sequence]
   (first (filter predicate sequence)))

--- a/components/util/src/polylith/clj/core/util/interface.clj
+++ b/components/util/src/polylith/clj/core/util/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface
+(ns ^:no-doc polylith.clj.core.util.interface
   (:require [polylith.clj.core.util.core :as core]))
 
 (defn find-first [predicate sequence]

--- a/components/util/src/polylith/clj/core/util/interface/color.clj
+++ b/components/util/src/polylith/clj/core/util/interface/color.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface.color
+(ns ^:no-doc polylith.clj.core.util.interface.color
   (:require [polylith.clj.core.util.colorizer :as colorizer]
             [polylith.clj.core.util.color-splitter :as color-splitter]))
 

--- a/components/util/src/polylith/clj/core/util/interface/exception.clj
+++ b/components/util/src/polylith/clj/core/util/interface/exception.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface.exception
+(ns ^:no-doc polylith.clj.core.util.interface.exception
   (:require [clojure.stacktrace :as stacktrace]))
 
 (defn print-error-message [e]

--- a/components/util/src/polylith/clj/core/util/interface/os.clj
+++ b/components/util/src/polylith/clj/core/util/interface/os.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface.os
+(ns ^:no-doc polylith.clj.core.util.interface.os
   (:require [polylith.clj.core.util.os :as os]))
 
 (defn windows? []

--- a/components/util/src/polylith/clj/core/util/interface/str.clj
+++ b/components/util/src/polylith/clj/core/util/interface/str.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface.str
+(ns ^:no-doc polylith.clj.core.util.interface.str
   (:require [clojure.string :as str]
             [polylith.clj.core.util.str :as str-util])
   (:refer-clojure :exclude [drop-last]))

--- a/components/util/src/polylith/clj/core/util/interface/time.clj
+++ b/components/util/src/polylith/clj/core/util/interface/time.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.interface.time
+(ns ^:no-doc polylith.clj.core.util.interface.time
   (:require [polylith.clj.core.util.time :as time]))
 
 (defn current-time []

--- a/components/util/src/polylith/clj/core/util/os.clj
+++ b/components/util/src/polylith/clj/core/util/os.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.os
+(ns ^:no-doc polylith.clj.core.util.os
   (:require [clojure.string :as str]))
 
 (defn windows-os? []

--- a/components/util/src/polylith/clj/core/util/str.clj
+++ b/components/util/src/polylith/clj/core/util/str.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.str
+(ns ^:no-doc polylith.clj.core.util.str
   (:require [clojure.string :as str]
             [polylith.clj.core.util.core :as core])
   (:refer-clojure :exclude [drop-last]))

--- a/components/util/src/polylith/clj/core/util/time.clj
+++ b/components/util/src/polylith/clj/core/util/time.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.util.time
+(ns ^:no-doc polylith.clj.core.util.time
   (:import (java.util Date)))
 
 (defn current-time []

--- a/components/validator/src/polylith/clj/core/validator/core.clj
+++ b/components/validator/src/polylith/clj/core/validator/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.core
+(ns ^:no-doc polylith.clj.core.validator.core
   (:require [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.validator.m101-illegal-namespace-deps :as m101]
             [polylith.clj.core.validator.m102-function-or-macro-is-defined-twice :as m102]

--- a/components/validator/src/polylith/clj/core/validator/datashape/dispatcher.clj
+++ b/components/validator/src/polylith/clj/core/validator/datashape/dispatcher.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.datashape.dispatcher
+(ns ^:no-doc polylith.clj.core.validator.datashape.dispatcher
   (:require [polylith.clj.core.validator.datashape.toolsdeps1 :as toolsdeps1]
             [polylith.clj.core.validator.datashape.toolsdeps2 :as toolsdeps2]))
 

--- a/components/validator/src/polylith/clj/core/validator/datashape/shared.clj
+++ b/components/validator/src/polylith/clj/core/validator/datashape/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.datashape.shared
+(ns ^:no-doc polylith.clj.core.validator.datashape.shared
   (:refer-clojure :exclude [alias]))
 
 (def alias [:map

--- a/components/validator/src/polylith/clj/core/validator/datashape/toolsdeps1.clj
+++ b/components/validator/src/polylith/clj/core/validator/datashape/toolsdeps1.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.datashape.toolsdeps1
+(ns ^:no-doc polylith.clj.core.validator.datashape.toolsdeps1
   (:require [malli.core :as m]
             [malli.error :as me]
             [polylith.clj.core.validator.datashape.shared :as shared]))

--- a/components/validator/src/polylith/clj/core/validator/datashape/toolsdeps2.clj
+++ b/components/validator/src/polylith/clj/core/validator/datashape/toolsdeps2.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.datashape.toolsdeps2
+(ns ^:no-doc polylith.clj.core.validator.datashape.toolsdeps2
   (:require [malli.core :as m]
             [malli.error :as me]
             [malli.util :as mu]

--- a/components/validator/src/polylith/clj/core/validator/interface.clj
+++ b/components/validator/src/polylith/clj/core/validator/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.interface
+(ns ^:no-doc polylith.clj.core.validator.interface
   (:require [polylith.clj.core.validator.core :as core]
             [polylith.clj.core.validator.datashape.dispatcher :as dispatch]
             [polylith.clj.core.validator.datashape.toolsdeps2 :as toolsdeps2]

--- a/components/validator/src/polylith/clj/core/validator/m101_illegal_namespace_deps.clj
+++ b/components/validator/src/polylith/clj/core/validator/m101_illegal_namespace_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m101-illegal-namespace-deps
+(ns ^:no-doc polylith.clj.core.validator.m101-illegal-namespace-deps
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]

--- a/components/validator/src/polylith/clj/core/validator/m102_function_or_macro_is_defined_twice.clj
+++ b/components/validator/src/polylith/clj/core/validator/m102_function_or_macro_is_defined_twice.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m102-function-or-macro-is-defined-twice
+(ns ^:no-doc polylith.clj.core.validator.m102-function-or-macro-is-defined-twice
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]

--- a/components/validator/src/polylith/clj/core/validator/m103_missing_defs.clj
+++ b/components/validator/src/polylith/clj/core/validator/m103_missing_defs.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m103-missing-defs
+(ns ^:no-doc polylith.clj.core.validator.m103-missing-defs
   (:require [clojure.string :as str]
             [clojure.set :as set]
             [polylith.clj.core.validator.shared :as shared]

--- a/components/validator/src/polylith/clj/core/validator/m104_circular_deps.clj
+++ b/components/validator/src/polylith/clj/core/validator/m104_circular_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m104-circular-deps
+(ns ^:no-doc polylith.clj.core.validator.m104-circular-deps
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/validator/src/polylith/clj/core/validator/m105_illegal_name_sharing.clj
+++ b/components/validator/src/polylith/clj/core/validator/m105_illegal_name_sharing.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m105-illegal-name-sharing
+(ns ^:no-doc polylith.clj.core.validator.m105-illegal-name-sharing
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]

--- a/components/validator/src/polylith/clj/core/validator/m106_multiple_interface_occurrences.clj
+++ b/components/validator/src/polylith/clj/core/validator/m106_multiple_interface_occurrences.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m106-multiple-interface-occurrences
+(ns ^:no-doc polylith.clj.core.validator.m106-multiple-interface-occurrences
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/validator/src/polylith/clj/core/validator/m107_missing_bricks_in_project.clj
+++ b/components/validator/src/polylith/clj/core/validator/m107_missing_bricks_in_project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m107-missing-bricks-in-project
+(ns ^:no-doc polylith.clj.core.validator.m107-missing-bricks-in-project
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.validator.shared :as shared]

--- a/components/validator/src/polylith/clj/core/validator/m108_project_with_multi_implementing_component.clj
+++ b/components/validator/src/polylith/clj/core/validator/m108_project_with_multi_implementing_component.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m108-project-with-multi-implementing-component
+(ns ^:no-doc polylith.clj.core.validator.m108-project-with-multi-implementing-component
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]

--- a/components/validator/src/polylith/clj/core/validator/m109_invalid_test_runner_constructor.clj
+++ b/components/validator/src/polylith/clj/core/validator/m109_invalid_test_runner_constructor.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m109-invalid-test-runner-constructor
+(ns ^:no-doc polylith.clj.core.validator.m109-invalid-test-runner-constructor
   (:require
    [clojure.string :as str]
    [polylith.clj.core.test-runner-contract.interface.initializers :as test-runner-initializers]

--- a/components/validator/src/polylith/clj/core/validator/m110_missing_or_invalid_config_file.clj
+++ b/components/validator/src/polylith/clj/core/validator/m110_missing_or_invalid_config_file.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m110-missing-or-invalid-config-file)
+(ns ^:no-doc polylith.clj.core.validator.m110-missing-or-invalid-config-file)
 
 (defn error [{:keys [error]}]
   {:type "error"

--- a/components/validator/src/polylith/clj/core/validator/m201_mismatching_parameters.clj
+++ b/components/validator/src/polylith/clj/core/validator/m201_mismatching_parameters.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m201-mismatching-parameters
+(ns ^:no-doc polylith.clj.core.validator.m201-mismatching-parameters
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.validator.shared :as shared]

--- a/components/validator/src/polylith/clj/core/validator/m202_missing_paths.clj
+++ b/components/validator/src/polylith/clj/core/validator/m202_missing_paths.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m202-missing-paths
+(ns ^:no-doc polylith.clj.core.validator.m202-missing-paths
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]

--- a/components/validator/src/polylith/clj/core/validator/m203_path_exists_in_both_dev_and_profile.clj
+++ b/components/validator/src/polylith/clj/core/validator/m203_path_exists_in_both_dev_and_profile.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m203-path-exists-in-both-dev-and-profile
+(ns ^:no-doc polylith.clj.core.validator.m203-path-exists-in-both-dev-and-profile
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]

--- a/components/validator/src/polylith/clj/core/validator/m204_lib_deps_exists_in_both_dev_and_profile.clj
+++ b/components/validator/src/polylith/clj/core/validator/m204_lib_deps_exists_in_both_dev_and_profile.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m204-lib-deps-exists-in-both-dev-and-profile
+(ns ^:no-doc polylith.clj.core.validator.m204-lib-deps-exists-in-both-dev-and-profile
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]

--- a/components/validator/src/polylith/clj/core/validator/m205_non_top_namespace.clj
+++ b/components/validator/src/polylith/clj/core/validator/m205_non_top_namespace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m205-non-top-namespace
+(ns ^:no-doc polylith.clj.core.validator.m205-non-top-namespace
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/validator/src/polylith/clj/core/validator/m206_unreadable_namespace.clj
+++ b/components/validator/src/polylith/clj/core/validator/m206_unreadable_namespace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m206-unreadable-namespace
+(ns ^:no-doc polylith.clj.core.validator.m206-unreadable-namespace
   (:require [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/validator/src/polylith/clj/core/validator/m207_unnecessary_components_in_project.clj
+++ b/components/validator/src/polylith/clj/core/validator/m207_unnecessary_components_in_project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.m207-unnecessary-components-in-project
+(ns ^:no-doc polylith.clj.core.validator.m207-unnecessary-components-in-project
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]

--- a/components/validator/src/polylith/clj/core/validator/message_printer.clj
+++ b/components/validator/src/polylith/clj/core/validator/message_printer.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.message-printer
+(ns ^:no-doc polylith.clj.core.validator.message-printer
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.color :as color]))
 

--- a/components/validator/src/polylith/clj/core/validator/shared.clj
+++ b/components/validator/src/polylith/clj/core/validator/shared.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.validator.shared
+(ns ^:no-doc polylith.clj.core.validator.shared
   (:require [clojure.string :as str]))
 
 (defn full-name

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.version.interface
+(ns ^:no-doc polylith.clj.core.version.interface
   (:refer-clojure :exclude [name])
   (:require [clojure.string :as str]
             [polylith.clj.core.system.interface :as system]))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/bases_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/bases_from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.bases-from-disk
+(ns ^:no-doc polylith.clj.core.workspace-clj.bases-from-disk
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.common.interface.config :as config]
             [polylith.clj.core.lib.interface :as lib]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_deps.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.brick-deps
+(ns ^:no-doc polylith.clj.core.workspace-clj.brick-deps
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.str :as str-util]))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_dirs.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_dirs.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.brick-dirs
+(ns ^:no-doc polylith.clj.core.workspace-clj.brick-dirs
   (:require [polylith.clj.core.common.interface.config :as config]))
 
 (defn source-dirs [brick-dir paths]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_paths.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/brick_paths.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.brick-paths
+(ns ^:no-doc polylith.clj.core.workspace-clj.brick-paths
   (:require [polylith.clj.core.file.interface :as file]))
 
 (defn existing-paths [brick-dir paths]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/components_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/components_from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.components-from-disk
+(ns ^:no-doc polylith.clj.core.workspace-clj.components-from-disk
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.common.interface.config :as config]
             [polylith.clj.core.file.interface :as file]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/core.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.core
+(ns ^:no-doc polylith.clj.core.workspace-clj.core
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.config-reader.interface :as config-reader]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/definitions.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/definitions.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.definitions
+(ns ^:no-doc polylith.clj.core.workspace-clj.definitions
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.util.interface :as util]))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/ignore_files_settings.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/ignore_files_settings.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.ignore-files-settings
+(ns ^:no-doc polylith.clj.core.workspace-clj.ignore-files-settings
   (:require [clojure.string :as str]))
 
 (defn file-path [namespace]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.interface
+(ns ^:no-doc polylith.clj.core.workspace-clj.interface
   (:require [polylith.clj.core.workspace-clj.core :as core]))
 
 (defn workspace-from-disk

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface_defs_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/interface_defs_from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.interface-defs-from-disk
+(ns ^:no-doc polylith.clj.core.workspace-clj.interface-defs-from-disk
   (:require [clojure.string :as str]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.common.interface :as common]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/namespaces_from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.namespaces-from-disk
+(ns ^:no-doc polylith.clj.core.workspace-clj.namespaces-from-disk
   (:require [clojure.string :as str]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.common.interface :as common]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/non_top_namespace.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/non_top_namespace.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.non-top-namespace
+(ns ^:no-doc polylith.clj.core.workspace-clj.non-top-namespace
   (:require [clojure.string :as str]
             [polylith.clj.core.file.interface :as file]
             [polylith.clj.core.common.interface :as common]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/profile.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/profile.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.profile
+(ns ^:no-doc polylith.clj.core.workspace-clj.profile
   (:require [clojure.string :as str]
             [polylith.clj.core.deps.interface :as deps]
             [polylith.clj.core.lib.interface :as lib]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_paths.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_paths.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.project-paths
+(ns ^:no-doc polylith.clj.core.workspace-clj.project-paths
   (:require [polylith.clj.core.path-finder.interface.criterias :as c]
             [polylith.clj.core.path-finder.interface.extract :as extract]
             [polylith.clj.core.path-finder.interface.select :as select]))

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_settings.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/project_settings.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.project-settings)
+(ns ^:no-doc polylith.clj.core.workspace-clj.project-settings)
 
 (defn convert-test [global-test {:keys [test] :as project-settings}]
   (cond-> project-settings

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/projects_from_disk.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/projects_from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.projects-from-disk
+(ns ^:no-doc polylith.clj.core.workspace-clj.projects-from-disk
   (:require [clojure.set :as set]
             [clojure.string :as str]
             [clojure.tools.deps.util.maven :as mvn]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/tag_pattern.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/tag_pattern.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.tag-pattern)
+(ns ^:no-doc polylith.clj.core.workspace-clj.tag-pattern)
 
 (defn patterns [tag-patterns stable-tag-pattern release-tag-pattern]
   (merge tag-patterns

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/ws_config.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/ws_config.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.ws-config
+(ns ^:no-doc polylith.clj.core.workspace-clj.ws-config
   (:require [polylith.clj.core.config-reader.interface :as config-reader]))
 
 (defn ws-config-from-disk [ws-dir]

--- a/components/workspace-clj/src/polylith/clj/core/workspace_clj/ws_reader.clj
+++ b/components/workspace-clj/src/polylith/clj/core/workspace_clj/ws_reader.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace-clj.ws-reader)
+(ns ^:no-doc polylith.clj.core.workspace-clj.ws-reader)
 
 (def reader
   {:name "polylith-clj"

--- a/components/workspace/src/polylith/clj/core/workspace/base.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/base.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.base
+(ns ^:no-doc polylith.clj.core.workspace.base
   (:require [polylith.clj.core.deps.interface :as deps]
             [polylith.clj.core.workspace.loc :as loc]
             [polylith.clj.core.workspace.lib-imports :as lib-imp]))

--- a/components/workspace/src/polylith/clj/core/workspace/component.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/component.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.component
+(ns ^:no-doc polylith.clj.core.workspace.component
   (:require [polylith.clj.core.deps.interface :as deps]
             [polylith.clj.core.workspace.loc :as loc]
             [polylith.clj.core.workspace.lib-imports :as lib-imp]))

--- a/components/workspace/src/polylith/clj/core/workspace/core.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.core
+(ns ^:no-doc polylith.clj.core.workspace.core
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.validator.interface :as validator]
             [polylith.clj.core.workspace.settings :as s]

--- a/components/workspace/src/polylith/clj/core/workspace/interface.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.interface
+(ns ^:no-doc polylith.clj.core.workspace.interface
   (:require [polylith.clj.core.workspace.core :as core]
             [polylith.clj.core.workspace.text-table.info-table :as info-table])
   (:gen-class))

--- a/components/workspace/src/polylith/clj/core/workspace/interfaces.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/interfaces.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.interfaces)
+(ns ^:no-doc polylith.clj.core.workspace.interfaces)
 
 (defn ->interface [[_ [{:keys [name interface]}]]]
   {:name (:name interface)

--- a/components/workspace/src/polylith/clj/core/workspace/lib_imports.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/lib_imports.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.lib-imports
+(ns ^:no-doc polylith.clj.core.workspace.lib-imports
   (:require [clojure.string :as str]))
 
 (defn library? [import suffixed-top-ns interface-names]

--- a/components/workspace/src/polylith/clj/core/workspace/loc.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/loc.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.loc
+(ns ^:no-doc polylith.clj.core.workspace.loc
   (:require [polylith.clj.core.file.interface :as file]))
 
 (defn lines-of-code-source [ws-dir namespaces]

--- a/components/workspace/src/polylith/clj/core/workspace/project.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/project.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.project
+(ns ^:no-doc polylith.clj.core.workspace.project
   (:require [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.deps.interface :as proj-deps]
             [polylith.clj.core.file.interface :as file]

--- a/components/workspace/src/polylith/clj/core/workspace/settings.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.settings
+(ns ^:no-doc polylith.clj.core.workspace.settings
   (:require [polylith.clj.core.workspace.settings.alias :as alias]
             [polylith.clj.core.workspace.settings.test :as test]))
 

--- a/components/workspace/src/polylith/clj/core/workspace/settings/alias.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings/alias.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.settings.alias
+(ns ^:no-doc polylith.clj.core.workspace.settings.alias
   (:require [clojure.set :as set]))
 
 (defn project-name->alias [index project-name]

--- a/components/workspace/src/polylith/clj/core/workspace/settings/test.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/settings/test.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.settings.test)
+(ns ^:no-doc polylith.clj.core.workspace.settings.test)
 
 (def default-test-runner
   'polylith.clj.core.clojure-test-test-runner.interface/create)

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/active_profiles.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/active_profiles.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.active-profiles
+(ns ^:no-doc polylith.clj.core.workspace.text-table.active-profiles
   (:require [clojure.string :as str]
             [polylith.clj.core.text-table.interface :as text-table]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/info_table.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/info_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.info-table
+(ns ^:no-doc polylith.clj.core.workspace.text-table.info-table
   (:require [clojure.string :as str]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.util.interface.color :as color]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/number_of_entities.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/number_of_entities.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.number-of-entities
+(ns ^:no-doc polylith.clj.core.workspace.text-table.number-of-entities
   (:require [polylith.clj.core.text-table.interface :as text-table]))
 
 (defn table [{:keys [settings projects bases components interfaces]}]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/profile.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/profile.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.profile)
+(ns ^:no-doc polylith.clj.core.workspace.text-table.profile)
 
 (defn profile-sorting [profile default-profile-name]
   [(not= default-profile-name profile) profile])

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/project_table.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/project_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.project-table
+(ns ^:no-doc polylith.clj.core.workspace.text-table.project-table
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]
             [polylith.clj.core.path-finder.interface.extract :as extract]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/stable_since.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/stable_since.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.stable-since
+(ns ^:no-doc polylith.clj.core.workspace.text-table.stable-since
   (:require [clojure.string :as str]
             [polylith.clj.core.text-table.interface :as text-table]
             [polylith.clj.core.util.interface.color :as color]))

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table
   (:require [polylith.clj.core.text-table.interface :as text-table]
             [polylith.clj.core.workspace.text-table.profile :as profile]
             [polylith.clj.core.workspace.text-table.ws-table-column.ifc-column :as ifc-column]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/brick_column.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/brick_column.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table-column.brick-column
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table-column.brick-column
   (:require [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.text-table.interface :as text-table]))
 

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/ifc_column.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/ifc_column.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table-column.ifc-column
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table-column.ifc-column
   (:require [polylith.clj.core.text-table.interface :as text-table]))
 
 (defn ifc-name [component]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/loc_columns.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/loc_columns.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table-column.loc-columns
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table-column.loc-columns
   (:require [polylith.clj.core.text-table.interface :as text-table]))
 
 (defn loc-column [header loc-key bricks column thousand-separator]

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/profile_columns.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/profile_columns.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table-column.profile-columns
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table-column.profile-columns
   (:require [polylith.clj.core.text-table.interface :as text-table]
             [polylith.clj.core.path-finder.interface.extract :as extract]
             [polylith.clj.core.path-finder.interface.status :as status]))

--- a/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/project_columns.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/text_table/ws_table_column/project_columns.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.text-table.ws-table-column.project-columns
+(ns ^:no-doc polylith.clj.core.workspace.text-table.ws-table-column.project-columns
   (:require [polylith.clj.core.path-finder.interface.criterias :as c]
             [polylith.clj.core.path-finder.interface.extract :as extract]
             [polylith.clj.core.path-finder.interface.select :as select]

--- a/components/ws-explorer/src/polylith/clj/core/ws_explorer/core.clj
+++ b/components/ws-explorer/src/polylith/clj/core/ws_explorer/core.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-explorer.core
+(ns ^:no-doc polylith.clj.core.ws-explorer.core
   (:require [clojure.pprint :as pp]
             [clojure.string :as str]
             [puget.printer :as puget]

--- a/components/ws-explorer/src/polylith/clj/core/ws_explorer/interface.clj
+++ b/components/ws-explorer/src/polylith/clj/core/ws_explorer/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-explorer.interface
+(ns ^:no-doc polylith.clj.core.ws-explorer.interface
   (:require [polylith.clj.core.ws-explorer.core :as core]))
 
 (defn extract [workspace get]

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_0_to_1.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_0_to_1.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-0-to-1
+(ns ^:no-doc polylith.clj.core.ws-file.from-0-to-1
   (:require [polylith.clj.core.git.interface :as git]
             [polylith.clj.core.version.interface :as ver])
   (:refer-clojure :exclude [alias]))

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-1-to-2
+(ns ^:no-doc polylith.clj.core.ws-file.from-1-to-2
   (:require [polylith.clj.core.ws-file.from-1-to-2.skip-ws-dir-in-paths :as skip-ws-dir-in-paths]
             [polylith.clj.core.ws-file.from-1-to-2.update-project-deps :as update-project-deps]))
 

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/converter.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/converter.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-1-to-2.converter
+(ns ^:no-doc polylith.clj.core.ws-file.from-1-to-2.converter
   (:require [polylith.clj.core.ws-file.from-1-to-2.skip-ws-dir-in-paths :as skip-ws-dir-in-paths]
             [polylith.clj.core.ws-file.from-1-to-2.update-project-deps :as update-project-deps]))
 

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/skip_ws_dir_in_paths.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/skip_ws_dir_in_paths.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-1-to-2.skip-ws-dir-in-paths
+(ns ^:no-doc polylith.clj.core.ws-file.from-1-to-2.skip-ws-dir-in-paths
   (:require [polylith.clj.core.util.interface.str :as str-util]))
 
 (defn skip-ws-dir-in-file-path [{:keys [file-path] :as source-ns} ws-dir]

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/update_project_deps.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_1_to_2/update_project_deps.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-1-to-2.update-project-deps)
+(ns ^:no-doc polylith.clj.core.ws-file.from-1-to-2.update-project-deps)
 
 (defn source-dep [{:keys [direct indirect circular direct-ifc missing-ifc]}]
   (let [missing-ifc-and-bases (or direct-ifc missing-ifc)]

--- a/components/ws-file/src/polylith/clj/core/ws_file/from_disk.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/from_disk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.from-disk
+(ns ^:no-doc polylith.clj.core.ws-file.from-disk
   (:require [polylith.clj.core.ws-file.from-0-to-1 :as from-0-to-1]
             [polylith.clj.core.ws-file.from-1-to-2.converter :as from-1-to-2]
             [polylith.clj.core.ws-file.version-converter :as version-converter]

--- a/components/ws-file/src/polylith/clj/core/ws_file/interface.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/interface.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.interface
+(ns ^:no-doc polylith.clj.core.ws-file.interface
   (:require [polylith.clj.core.ws-file.from-disk :as from-disk]))
 
 (defn read-ws-from-file [ws-file user-input]

--- a/components/ws-file/src/polylith/clj/core/ws_file/version_converter.clj
+++ b/components/ws-file/src/polylith/clj/core/ws_file/version_converter.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.ws-file.version-converter
+(ns ^:no-doc polylith.clj.core.ws-file.version-converter
   (:require [polylith.clj.core.version.interface :as version]))
 
 (defn convert [{:keys [version] :as workspace}]


### PR DESCRIPTION
Mark internal namespaces with `:no-doc` metadata.

This communicates to tools such as cljdoc what is internal and
should not be included in API docs.

At this time, the public API consists only of:
- polylith.clj.core.api.interface
- polylith.clj.core.test-runner-contract.interface

And also tidy up docstring formatting for TestRunner