### PR TITLE
Fix NPE when taking the size of a directory

### DIFF
--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -31,7 +31,7 @@
       (println (str "Warning. " message " '" path "': " (.getMessage e))))))
 
 (defn size [path]
-  (cond (fs/directory? path) (apply + (pmap size (.listFiles (io/file path))))
+  (cond (fs/directory? path) (apply + (pmap #(or (size %) 0) (.listFiles (io/file path))))
         (fs/file? path) (fs/size path)
         :else nil))
 


### PR DESCRIPTION
size calls itself and sums the results, but size can return nil in some circumstances. For example, a broken symlink will have a size of nil. This results in the poly tool crashing at startup.

The fix adds an (or ,,, 0) form around the sub-call of size