### PR TITLE
Fix filename/namespace mismatch in profile.adoc

### DIFF
--- a/doc/profile.adoc
+++ b/doc/profile.adoc
@@ -205,8 +205,8 @@ example
 ├── components
 │   └── user-remote
 │       └── src
-│           ├── se.example.user_remote.core.clj
-│           └── se.example.user_remote.interface.clj
+│           ├── se.example.user.core.clj
+│           └── se.example.user.interface.clj
 ----
 
 ...with this content:


### PR DESCRIPTION
Fixes user-remote code snippets with filenames not matching their declared namespaces