### PR TITLE
bb doc: improve docker dameon error msg

### DIFF
--- a/scripts/cljdoc_preview.clj
+++ b/scripts/cljdoc_preview.clj
@@ -29,7 +29,12 @@
   (let [missing-cmds (doall (remove fs/which ["git" "docker"]))]
     (when (seq missing-cmds)
       (status/die 1 (string/join "\n" ["Required commands not found:"
-                                       (string/join "\n" missing-cmds)])))))
+                                       (string/join "\n" missing-cmds)]))))
+  (let [{:keys [exit err]} (process/shell {:continue true :err :string :out :string}
+                                           "docker version")]
+    (when-not (zero? exit)
+      (status/die 1 (str "Docker check failed with:\n\n"
+                         err)))))
 
 ;;
 ;; project build info


### PR DESCRIPTION
If the docker daemon is not running we now present a much more concise error message (the cause was previously shown but obscured by a big stack trace).