### PR TITLE
Review and update Introduction

### DIFF
--- a/doc/introduction.adoc
+++ b/doc/introduction.adoc
@@ -5,23 +5,15 @@ ifndef::env-cljdoc[]
 TIP: For a richer experience, we recommend reading on {cljdoc-doc-url}/introduction[cljdoc].
 endif::[]
 
-This documentation offers a practical guide to using the Polylith tool.
-Our goal is to teach you the value of components and how they bring context to the development experience.
-We want to empower you to build decoupled and scalable systems from day one.
+This documentation aims to be a practical guide to this tool with lots of code examples.
+We encourage you to follow the code examples and try it out yourself.
+We will guide you through the steps of creating a workspace with projects composed of components, bases, and libraries and how to work with them from the development environment and the interactive shell.
 
-We have included many code examples.
-We strongly encourage you to try them out!
+We will give a short introduction to tools.deps and how to use tools.build to create deployable artifacts.
+We will explain how git is used to tag the code and how it enables us to test and release the code incrementally.
 
-You will learn how to:
+We will show how profiles will help us work from a single development environment for maximum efficiency and how dependencies and library usage can be displayed.
 
-* Create a workspace with projects composed of components, bases, and libraries.
-* Use the development environment and the interactive shell.
-* Use tools.deps and then tools.build to create deployable artifacts.
-
-We will explain how:
-
-* We leverage git tagging to support incremental tests and releases.
-* Profiles allow us to work efficiently from a single development environment.
-* To easily understand your dependency and library usage.
+We will explain the value of components and how they bring context to our development experience, which will help us build decoupled and scalable systems from day one.
 
 Let's begin!

--- a/doc/introduction.adoc
+++ b/doc/introduction.adoc
@@ -1,15 +1,27 @@
 = Introduction
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc
 
-This {cljdoc-doc-url}/readme[documentation] aims to be a practical guide to this tool with lots of code examples.
-We encourage you to follow the code examples and try it out yourself.
-We will guide you through the steps of creating a workspace with projects composed of components, bases, and libraries and how to work with them from the development environment and the interactive shell.
+ifndef::env-cljdoc[]
+TIP: For a richer experience, we recommend reading on {cljdoc-doc-url}/introduction[cljdoc].
+endif::[]
 
-We will give a short introduction to tools.deps and how to use tools.build to create deployable artifacts.
-We will explain how git is used to tag the code and how it enables us to test and release the code incrementally.
+This documentation offers a practical guide to using the Polylith tool.
+Our goal is to teach you the value of components and how they bring context to the development experience.
+We want to empower you to build decoupled and scalable systems from day one.
 
-We will show how profiles will help us work from a single development environment for maximum efficiency and how dependencies and library usage can be displayed.
+We have included many code examples.
+We strongly encourage you to try them out!
 
-We will explain the value of components and how they bring context to our development experience, which will help us build decoupled and scalable systems from day one.
+You will learn how to:
+
+* Create a workspace with projects composed of components, bases, and libraries.
+* Use the development environment and the interactive shell.
+* Use tools.deps and then tools.build to create deployable artifacts.
+
+We will explain how:
+
+* We leverage git tagging to support incremental tests and releases.
+* Profiles allow us to work efficiently from a single development environment.
+* To easily understand your dependency and library usage.
 
 Let's begin!


### PR DESCRIPTION
Moved link to cljdoc to a tip that is only displayed if not already reading on cljdoc. Cljoc link adjusted to point to article we are viewing (introduction) instead of readme.

Same content but re-organized.

Starts with goal, then show the details to further entice reader.

Used bullet points to make text easier to digest.

Tried to be more succinct by getting rid of unnecessary words or rephrasing to use less words.