### PR TITLE
Review and update Development doc

### DIFF
--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -1,50 +1,58 @@
 = Development
 
-When working with a Polylith codebase, we are free to choose any editor/IDE we like, for example:
+When working with a Polylith codebase, you are free to choose any editor/IDE you like, for example:
 
-* https://www.gnu.org/software/emacs/[Emacs] / https://github.com/clojure-emacs/cider[Cider]
+* https://www.gnu.org/software/emacs/[Emacs] with https://cider.mx/[Cider]
 
-* https://code.visualstudio.com/[VSCode] / https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva[Calva]
+* https://code.visualstudio.com/[VSCode] with https://marketplace.visualstudio.com/items?itemName=betterthantomorrow.calva[Calva]
 
-* https://www.jetbrains.com/idea/[IDEA] / https://cursive-ide.com/[Cursive].
+* https://www.jetbrains.com/idea/[IntelliJ IDEA] with https://cursive-ide.com/[Cursive]
 
-Here we will use Cursive, and if you do too, make sure you have https://cursive-ide.com/userguide/deps.html[tools.deps] configured correctly.
+== IntelliJ IDEA with Cursive Setup
 
-Let's get started by creating a project.
-From the menu, select `File > New > Project from existing sources`.
-Select the `deps.edn` file, the desired version of SDK and finish the wizard.
+Here, we share some specific setup instructions when using Cursive.
 
-If you are a Cursive user, and use version `1.13.0` or later, then you need to select "Resolve over whole project" in the settings:
+=== Cursive Setup
+First, make sure you have https://cursive-ide.com/userguide/deps.html[tools.deps] configured correctly.
+
+To import a Polylith xref:workspace.adoc[workspace] as a project:
+
+. Select `File > New > Project from Existing Sources...` from the menu.
+. A wizard will guide you through the import:
+.. Start with selecting the workspace `deps.edn` file
+.. When asked, choose your desired version of the Java SDK
+.. Otherwise, hit `Next` and finally `Create`.
+
+If you are using Cursive `1.13.0` or later, you must enable `Resolve over whole project` under +
+`File > Settings... > Languages & Frameworks > Clojure > Project Specific Options`:
 
 image::images/development/idea-resolve-over-whole-project.png[width=600]
 
-Make sure to activate the `:dev` alias (and press the "two arrows" icon to refresh):
+From the `Clojure Deps` tab (by default, it's on the far right), enable `dev` under `Aliases`, then press the icon with two arrows to refresh:
 
 image::images/development/activate-dev-alias.png[width=250]
 
-Let's create a REPL by clicking `Edit Configurations...`:
+To create a REPL, select `Current File > Edit Configurations...`:
 
 image::images/development/edit-configuration.png[width=200]
 
-Click the `+` sign and select `Clojure REPL > Local`:
+Then click the `+` sign and select `Clojure REPL > Local`:
 
 image::images/development/create-local-repl.png[width=250]
 
-Fill in:
+Configure like so: 
 
-* Name: `REPL`
-* Which type of REPL to run: `nREPL`
-* Run with Deps: (select)
-* Options: `-A:dev:test`
-* Module: `example`
+* `Name:` type `REPL`
+* `Which type of REPL to run` choose `nREPL`
+* `How to run it` choose `Run with Deps`
+** `Options:` type `-A:dev:test`
+* `Common Options > Module:` select your Polylith workspace directory, e.g., `example`
 
-Press OK and start the REPL in debug mode, by clicking the bug icon:
+Press `OK`. Now start the REPL in debug mode by clicking the bug icon:
 
 image::images/development/debug.png[width=150]
 
-{nbsp} +
-
-When this turns up:
+Under the `REPL` view, you should soon see something like:
 
 [source,shell]
 ----
@@ -52,40 +60,39 @@ Clojure 1.11.1
 nREPL server started on port 56855 on host localhost - nrepl://localhost:56855
 ----
 
-...we are ready to go!
+You have configured everything https://github.com/clojure/tools.deps[tools.deps] needs and are ready to write some Clojure code!
 
-If we look at the `deps.edn` file again, we can see that "development/src" was already added to the path:
+=== Trying Out Your Development Environment
+
+Look at the xref:workspace.adoc[workspace] generated `deps.edn` file.
+Notice that it already includes `development/src` on the path under the `:dev` alias:
 
 [source,shell]
 ----
  :aliases  {:dev {:extra-paths ["development/src"]
 ----
 
-This gives us access to the `development/src` directory so that we can work with the code.
+(You might remember we had you enable the `dev` alias above under `Clojure Deps` and for the REPL via `-A:dev:test`.)
 
-The "development/src" path belongs to the `dev` alias which we activated previously and also added to the REPL by selecting the `-A:dev:test` option.
-This means that we have configured everything that https://github.com/clojure/tools.deps.alpha[tools.deps] needs and that we are ready to write some Clojure code!
+To get started, create a dev namespace.
+We suggest you use `dev` as a top namespace here, not your xref:workspace.adoc[workspace] top namespace.
+This strategy keeps your production code entirely separate from your development code.
 
-To do that we first need to create a namespace.
-We suggest that you use `dev` as a top namespace here and not the workspace top namespace `se.example`.
-The reason is that we don't want to mix the code we put here with the production code.
+One way to structure dev code is to give each developer their own namespace under `dev`.
+Following this pattern, create the namespace `dev.lisa`: +
+Right-click on the `development/src` directory, select `New > Clojure Namespace`, and type `dev.lisa`.
 
-One way of structuring the code is to give all developers their own namespace under the `dev` top namespace.
-Let's follow that pattern and create the namespace `dev.lisa`.
-
-Right-click on the `development/src` directory and select `New > Clojure Namespace` and type `dev.lisa`:
-
-When this dialog turns up, select `Don't ask again` and click the `Add` button:
+A dialog will pop up and ask you if you want to add the file to git:
 
 image::images/development/add-file-to-git.png[width=600]
 
-If the namespace is not recognised, you may need to click the refresh button (two arrows):
+Check `Don't ask again` and click the `Add` button.
+
+If the namespace is not recognized, you may need to click the icon with two arrows under the `Clojure Deps` tab to refresh: 
 
 image::images/development/refresh.png[width=150]
 
-{nbsp} +
-
-Now let's write some code:
+Now you can write some code in `lisa.clj`:
 
 [source,clojure]
 ----
@@ -94,5 +101,9 @@ Now let's write some code:
 (+ 1 2 3)
 ----
 
-Make sure the namespace is loaded, by sending `(ns dev.lisa)` to the REPL.
-If we then send `(+ 1 2 3)` to the REPL we should get `6` back, and if we do, it means that we now have a working development environment!
+Load the namespace by sending `(ns dev.lisa)` to the REPL.
+
+Send `(+ 1 2 3)` to the REPL.
+You should see `6` in the REPL view.
+
+Congratulations, you now have a working development environment!


### PR DESCRIPTION
Specific instructions are for Cursive only, make that clearer with headings.

Otherwise just edited for clarity.

Notes:
- I notice extra spacing added under images. I removed it. We can address image/text spacing in cljdoc if we need to.
- I expect the advice Cursive specific instructions on setting up a dev namespaces are repeated elsewhere? If not, we might want to come back and generalize this advice for non-Cursive users.
- As of this writing the Cursive docs on tools.deps setup might be stale, but that's not something under our domain of control.