### PR TITLE
readme: tweak wip note

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -14,7 +14,6 @@ https://clojurians.slack.com/messages/C013B7MQHJQ[image:https://badgen.net/badge
 
 NOTE: *Work in Progress*: While we are very proud of our documentation, we are currently working to make it even better!
 To give you a sneak peek, we built this `{snapshot-version}` release from our https://github.com/polyfy/polylith/tree/master[master] branch.
-Current snapshot version is displayed by executing `clojure -M:poly ws get:version:release:snapshot` or by starting a xref:shell.adoc[shell] from the master branch with e.g. `clojure -M:poly`.
 
 Polylith is made by developers for developers.
 Our goal is to maximize productivity and increase the quality of the systems we create.


### PR DESCRIPTION
Remove instructions on how to get poly version.
Joakim and I felt it might be more confusing than helpful at this very early point in the docs.