### PR TITLE
introduction doc: tutorial concept

### DIFF
--- a/doc/introduction.adoc
+++ b/doc/introduction.adoc
@@ -5,9 +5,12 @@ ifndef::env-cljdoc[]
 TIP: For a richer experience, we recommend reading on {cljdoc-doc-url}/introduction[cljdoc].
 endif::[]
 
-This documentation aims to be a practical guide to this tool with lots of code examples.
-We encourage you to follow the code examples and try it out yourself.
-The final version of the code example can be found link:https://github.com/polyfy/polylith/tree/master/examples/doc-example[here].
+This documentation is a practical guide to the `poly` tool.
+
+We include many code examples.
+They act as an ongoing tutorial as you read sequentially through the documentation.
+We encourage you to follow the tutorial examples and try them out yourself.
+For your convenience, we provide the end result link:/examples/doc-example[here].
 
 We will guide you through the steps of creating a workspace with projects composed of components, bases, and libraries and how to work with them from the development environment and the interactive shell.
 


### PR DESCRIPTION
Add concept that code examples provide an ongoing tutorial.

This should now provide something we can link back to from other docs that include tutorial code examples.

Tried to make minimal changes as I know Joakim wants to maintain a specific tone to the introduction.

Fix link to end result of tutorial so that it links back to GitHub released revision.