### PR TITLE
Review and Update Tools.deps doc

### DIFF
--- a/doc/install.adoc
+++ b/doc/install.adoc
@@ -13,24 +13,33 @@ h| Example usage:
 | `poly help`
 | `clojure -M:poly help`
 a| `clojure -Tpoly help` +
-⚠️ xref:clojure-cli-tool.adoc[command line uses Clojure Tools exec args syntax] 
+⚠️ xref:clojure-cli-tool.adoc[command line uses Clojure Tools exec args syntax]
 
 h| Installed via:
 | Homebrew on macOS, otherwise via Nix or a manual download
-| Adding a `:poly` alias in `./deps.edn` 
+| Adding a `:poly` alias in `./deps.edn`
 | Clojure Tools
 
 h| Can be invoked from:
-| Any directory 
-| A Polylith xref:workspace.adoc[workspace] directory 
-| Any directory 
+| Any directory
+| A Polylith xref:workspace.adoc[workspace] directory
+| Any directory
 
 h| Switch `poly` version via:
-| `@<version>` if using HomeBrew 
-| Updating dependency for `:poly` alias in `./deps.edn` 
+| `@<version>` if using HomeBrew
+| Updating dependency for `:poly` alias in `./deps.edn`
 | Reinstalling with Clojure Tools
 
+h| Pre-compiled for faster startup? link:#startup-time[^1^]
+| Yes
+| No
+| No
+
 |===
+
+Table Notes:
+[[startup-time]]
+. If you follow our recommendation of using the `poly` xref:shell.adoc[shell], startup time is not much of a concern.
 
 We prefer to install `poly` as a stand-alone and/or as a Clojure CLI dep.
 Your preference is fine too; there are no wrong choices.
@@ -52,7 +61,7 @@ To install the `poly` tool on macOS, run:
 brew install polyfy/polylith/poly
 ----
 
-The `poly` https://github.com/polyfy/polylith/blob/master/build/resources/brew/exec[script] is now installed and added to the system path. 
+The `poly` https://github.com/polyfy/polylith/blob/master/build/resources/brew/exec[script] is now installed and added to the system path.
 The script uses Java to launch the poly tool.
 
 If you get an error such as "openjdk-13.0.2.jdk could not be opened...", try:
@@ -107,11 +116,11 @@ Verify the installation by running `poly help`.
 
 === Troubleshooting Clojure CLI Install on Windows
 
-TIP: If you are running on Windows, you might prefer to use the more user-friendly https://github.com/casselc/clj-msi[clj-msi]. 
+TIP: If you are running on Windows, you might prefer to use the more user-friendly https://github.com/casselc/clj-msi[clj-msi].
 
 TIP: Windows users should also consider using WSL and then follow instructions under <<install-on-linux>>.
 
-If you have installed Clojure's Powershell module and see an error like: 
+If you have installed Clojure's Powershell module and see an error like:
 
 [source,shell]
 ----
@@ -206,7 +215,7 @@ Navigate to your newly created workspace directory and verify via `clojure -M:po
 
 TIP: If you have no interest in using any stand-alone variant of `poly` and want to use `poly` only as a dependency, see xref:workspace.adoc#bootstrap[Bootstrapping a Workspace].
 
-For more details on how `poly` is released, see docs on xref:polylith-ci-setup.adoc#releases[releases]. 
+For more details on how `poly` is released, see docs on xref:polylith-ci-setup.adoc#releases[releases].
 
 [#github-dependency]
 === Using a Git Dependency
@@ -229,7 +238,7 @@ Replace `INSERT-SHA-HERE` with a commit SHA from the Polylith repository, for ex
 2. Or some commit SHA from a work-in-progress branch you want to try
 
 === Specifying Logging Libraries
-You can add in the logging libraries you'd like to use with `poly` by adjusting your `:poly` alias in your workspace `./deps.edn` like so:    
+You can add in the logging libraries you'd like to use with `poly` by adjusting your `:poly` alias in your workspace `./deps.edn` like so:
 
 [source,clojure]
 ----
@@ -290,7 +299,7 @@ After which you can specify standard Polylith arguments:
 #####   _ __  ___| |_  _| |-| |_| |_
 #####  | '_ \/ _ \ | || | | |  _| ' \
 #####  | .__/\___/_|\_, |_|_|\__|_||_|
-       |_|          |__/ poly {poly-version} 
+       |_|          |__/ poly {poly-version}
 polylith$ info :loc
 ----
 
@@ -317,6 +326,13 @@ clojure -Ttools list
 ----
 clj -Ttools list
 ----
+
+But use `clojure` when launching a `poly` shell (see xref:tools-deps.adoc#clojure-vs-clj[clojure vs clj]):
+
+[source,shell]
+----
+clojure -Tpoly shell
+----
 ====
 
 You can get basic built-in help via Clojure CLI's help machinery:
@@ -338,4 +354,4 @@ The API is documented link:{cljdoc-api-url}/polylith[here].
 [#jvm-options]
 == JVM options
 You might want to specify more RAM to the `poly` tool and/or where the configuration file for logging is located.
-These can be conveyed via the `JVM_OPTS` environment variable which `poly` will passes along to the Java runtime at launch of poly stand-alone. 
+These can be conveyed via the `JVM_OPTS` environment variable which `poly` will passes along to the Java runtime at launch of poly stand-alone.

--- a/doc/tools-deps.adoc
+++ b/doc/tools-deps.adoc
@@ -1,41 +1,40 @@
 = Tools.deps
 
-This `poly` tool is built on top of tools.deps.
-To get the most out of it, we recommend you to read its https://github.com/clojure/tools.deps.alpha[documentation].
+We created the `poly` tool on top of Clojure tools.deps.
+If you are unfamiliar with tools.deps, we recommend that you read its https://github.com/clojure/tools.deps[documentation].
 
-When we created the workspace with the xref:commands#create-workspace[create workspace] command, the `poly` alias was also be added to `./deps.edn`:
+== The `poly` Alias
 
-[source,clojure]
-----
-    :poly {:main-opts ["-m" "polylith.clj.core.poly-cli.core"]
-           :extra-deps {polyfy/polylith
-                        {:git/url   "https://github.com/polyfy/polylith"
-                         :sha       "1b91de1cb96dd286c9f5f9bda6a97d62c40b67a7"
-                         :deps/root "projects/poly"}}}
-----
+When you xref:workspace.adoc[create a workspace], `poly` generates a workspace `deps.edn` that includes a `poly` alias.
+We cover details in our xref:install.adoc#use-as-dependency[install docs].
 
-This alias can now be used to execute the `poly` tool from the workspace root, e.g.:
+== clojure vs clj
 
-[source,shell]
-----
-cd ../..
-clojure -M:poly info
-----
-
-It takes longer to execute the `poly` tool this way, because it needs to compile the Clojure code first, but it also allows us to execute older or newer versions of the tool by selecting another `sha` from an https://github.com/polyfy/polylith/commits/master[existing commit].
-
-To speed things up we can always start a xref:commands.adoc#shell[shell]:
+Use `clojure` instead of `clj` when launching a `poly` xref:shell.adoc[shell] as xref:install.adoc#use-as-dependency[a clojure dependency]:
 
 [source,shell]
 ----
 clojure -M:poly
 ----
 
-== clojure vs clj
+****
+Or when using poly xref:install.adoc#install-as-clojure-cli-tool[as a Clojure tool]:
 
-In the example above, we started the `poly` tool using `clojure` which is preferable over `clj` when executing a program like the `poly` tool, and is well described https://betweentwoparens.com/blog/what-are-the-clojure-tools/#clj%2Fclojure[here].
+[source,shell]
+----
+clojure -Tpoly shell
+----
+****
 
-If we use `clj` instead, things will still work, but we will get a warning in some situations:
+****
+Why? There are two ways to run clojure:
+
+1. `clojure` - runs clojure programs
+2. `clj` - the same, but provides REPL command history support via `rlwrap`
+
+As described by https://betweentwoparens.com/blog/what-are-the-clojure-tools/#clj%2Fclojure[a "Between Two Parens" blog post], `rlwrap` can sometimes get in the way. This is the case for the `poly` shell.
+
+If you use `clj` instead of `clojure`, things will still work, but you will sometimes see warnings from `rlwrap`:
 
 [source,shell]
 ----
@@ -43,3 +42,6 @@ clj -M:poly
 ----
 
 image::images/toolsdeps/clj-poly-shell.png[width=600]
+
+You don't need that noise and confusion, so use `clojure` when launching a `poly` shell.
+****


### PR DESCRIPTION
The clojure vs clj discussion now also covers running clojure as a tool.

Now linking to install docs instead of reiterating what was said therein.

Moved startup time note to install docs.

Also: some end-of-line whitespace trimming (I think I accidentally added this on my first edits).