### PR TITLE
Review and update Git and Tagging docs

### DIFF
--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -1,4 +1,5 @@
 = Development
+:toc:
 
 When working with a Polylith codebase, you are free to choose any editor/IDE you like, for example:
 
@@ -8,6 +9,25 @@ When working with a Polylith codebase, you are free to choose any editor/IDE you
 
 * https://www.jetbrains.com/idea/[IntelliJ IDEA] with https://cursive-ide.com/[Cursive]
 
+== Generic Setup
+We only currently specifically describe <<idea-cursive>>.
+
+If you are using a different IDE, here's the generic goals:
+
+. Setup your IDE's REPL to startup with `dev` and `test` aliases
+. Notice that your xref:workspace.adoc[workspace] `./deps.edn` already has `development/src` on the path for the `dev` alias
+. Add sample source `development/src/dev/lisa.clj`:
++
+[source,clojure]
+----
+(ns dev.lisa)
+
+(+ 1 2 3)
+----
+. Evaluate `dev.lisa` in your IDE REPL to test.
+. Celebrate a successful IDE setup!
+
+[[idea-cursive]]
 == IntelliJ IDEA with Cursive Setup
 
 Here, we share some specific setup instructions when using Cursive.
@@ -40,7 +60,7 @@ Then click the `+` sign and select `Clojure REPL > Local`:
 
 image::images/development/create-local-repl.png[width=250]
 
-Configure like so: 
+Configure like so:
 
 * `Name:` type `REPL`
 * `Which type of REPL to run` choose `nREPL`
@@ -82,13 +102,14 @@ One way to structure dev code is to give each developer their own namespace unde
 Following this pattern, create the namespace `dev.lisa`: +
 Right-click on the `development/src` directory, select `New > Clojure Namespace`, and type `dev.lisa`.
 
+[[cursive-enable-auto-add]]
 A dialog will pop up and ask you if you want to add the file to git:
 
 image::images/development/add-file-to-git.png[width=600]
 
 Check `Don't ask again` and click the `Add` button.
 
-If the namespace is not recognized, you may need to click the icon with two arrows under the `Clojure Deps` tab to refresh: 
+If the namespace is not recognized, you may need to click the icon with two arrows under the `Clojure Deps` tab to refresh:
 
 image::images/development/refresh.png[width=150]
 

--- a/doc/git.adoc
+++ b/doc/git.adoc
@@ -1,21 +1,26 @@
 = Git
 
-We have already used the xref:commands.adoc#info[info] command a couple of times without explaining everything in its output.
+Here, we explore how `poly` works with https://git-scm.com/[git].
 
-Let's execute the xref:commands.adoc#info[info] command again to see the current state of the workspace:
+Let's continue with our xref:introduction.adoc[tutorial].
+The last thing we did in our tutorial was xref:build.adoc[add build support].
 
+We'll start with the xref:commands.adoc#info[info] command.
+We have had you run this command without explaining everything it outputs.
+Rerun `info` to see the current state of your workspace:
+
+[[info-all-changed-example]]
 [source,shell]
 ----
-cd ../../..
 poly info
 ----
-
 image::images/git/info.png[width=400]
 
-At the top we have the line `stable since: c91fdad` (you most likely have another git SHA/hash).
-To explain what this is, let's take it from the beginning.
+At the top, you'll notice `stable since: c91fdad` (your git short-SHA will differ from our `c91fdad`).
+What does this mean?
+Let's start from the beginning.
 
-If we pass in `:commit` when a Polylith workspace is created, these git commands are executed:
+When you specify `:commit` when xref:workspace.adoc[creating a Polylith workspace], `poly` executes these git commands on your behalf:
 
 [source,shell]
 ----
@@ -24,9 +29,11 @@ git add .
 git commit -m "Workspace created."
 ----
 
-If we don't pass in `:commit` to the xref:commands.adoc#create-workspace[create workspace] command then we have to perform these (or similar) commands manually.
+****
+If you don't specify `:commit` for the xref:commands.adoc#create-workspace[create workspace] command, it is up to you to execute the above `git` commands (or the equivalent) manually.
+****
 
-If we run `git log` from the workspace root, it returns something like this:
+Run `git log` from your `example` workspace root, and you'll see something like:
 
 [source,shell]
 ----
@@ -37,34 +44,37 @@ Date:   Thu Sep 3 06:11:23 2020 +0200
     Workspace created.
 ----
 
-This is the first and only commit of this repository so far.
-This is also the first _stable point in time_ of this workspace which the tool uses when it calculates what changes have been made (up till now).
-Notice that the first letters of the hash correspond to `stable since: c91fdad` and this is because it refers to this SHA-1 hash in git.
+This is the first and only commit for this git repository.
+Notice that the commit hash matches the short-SHA from the `info` command output: `stable since: c91fdad`.
+This first commit is considered the first _stable point in time_ for this workspace.
 
-We told the IDE to automatically add new files to git, but if we didn't, we can add them now:
+The `info` command calculates what has changed since the current _stable point in time_.
+
+TIP: *Cursive users*:
+If you followed our xref:development.adoc#cursive-enable-auto-add[setup instructions], Cursive will automatically add new files to the git repository.
+
+If all files have not been added to git yet, add them now:
 
 [source,shell]
 ----
 git add --all
 ----
 
-The `command-line` and `development` projects, and the `user` and `cli` bricks are all marked with an asterisk, `*`.
-The way the tool calculates changes is to ask git by running this command internally:
+Look at the `info` command output again:
 
-[source,shell]
-----
-git diff c91fdad4a34927d9aacfe4b04ea2f304f3303282 --name-only
-----
+image::images/git/info.png[width=400]
 
-We can also run the xref:commands.adoc#diff[diff] command, which will execute the same git statement internally:
+Notice that `poly` has marked all projects (`command-line` and `development`) and all bricks (`user` and `cli`) with a trailing `*` (asterisk), meaning they have changed after the current _stable point in time_ (as described by `stable since: c91fdad`).
+
+Let's dig into how `poly` determines this.
+Run the xref:commands.adoc#diff[diff] command to see all files that have been added since the last commit:
 
 [source,shell]
 ----
 poly diff
 ----
 
-The output is the same (this assumes that you have https://git-scm.com/docs/git-add[added] the files to your git repository):
-
+You should see output like this:
 // scripts/output/git-diff.txt
 [source,shell]
 ----
@@ -84,19 +94,43 @@ projects/command-line/deps.edn
 workspace.edn
 ----
 
-Here we have the answer to where the `*` signs come from.
-The paths that start with `projects/command-line/`, `development/`, `components/user/` and `bases/cli/` makes the tool understand that `command-line`, `development`, `user` and `cli` are changed.
+We expect you are starting to see how `poly` decides to mark items as changed with the `*` (asterisk):
 
-When we created the workspace, a https://git-scm.com/docs/gitignore[.gitignore] file was also created for us.
-Now is a good time to add more rows here if needed:
+|===
+| The `poly` tool knows that there are changes in: | Because there are differences under dir:
+
+| `command-line` project
+| `projects/command-line/`
+
+| `development` project
+| `development/`
+
+| `user` brick
+| `component/user/`
+
+| `cli` brick
+| `bases/cli/`
+
+|===
+
+****
+Internally, the `diff` command runs:
 
 [source,shell]
 ----
-**/classes
-...
+git diff c91fdad4a34927d9aacfe4b04ea2f304f3303282 --name-only
 ----
 
-Let's add and commit the changed files:
+If your xref:workspace.adoc#workspace-root-under-git-root[workspace root isn't the same as your git root], the `diff` command will internally strip away the workspace directory.
+
+The workspace directory is available via `poly get:ws-local-dir` and will return `nil` if your workspace is at the git root.
+****
+
+When you created your xref:workspace.adoc[workspace], `poly` created a  https://git-scm.com/docs/gitignore[.gitignore] for you.
+Now is a good time to add more rules to `/.gitignore` if needed.
+
+[[add-and-commit]]
+Add and commit any new and changed files:
 
 [source,shell]
 ----
@@ -104,12 +138,14 @@ git add --all
 git commit -m "Created the user and cli bricks."
 ----
 
-Let's have a look at our workspace repository again:
+Have a look at our workspace repository commit history again:
 
 [source,shell]
 ----
 git log --pretty=oneline
 ----
+
+Your git SHAs will be different, but you'll see something like:
 
 [source,shell]
 ----
@@ -117,9 +153,6 @@ e7ebe683a775ec28b7c2b5d77e01e79d48149d13 (HEAD -> main) Created the user and cli
 c91fdad4a34927d9aacfe4b04ea2f304f3303282 Workspace created.
 ----
 
-If we run the xref:commands.adoc#info[info] command again, it will return the same result as before, and the reason is that we haven't told git to move the _stable point in time_ to our second commit.
-
-We said that the xref:commands.adoc#diff[diff] command returns the same result as `git diff SHA --name-only`.
-This is normally true, except for the case when the workspace lives inside a git repo.
-In that case, the `git diff` command will also return the workspace directory in the path (which is stripped away by the `poly` tool).
-This directory can be shown by executing `poly ws get:ws-local-dir`.
+If you rerun the xref:commands.adoc#info[info] command, it will return the same result as before.
+This is because you haven't moved your _stable point in time_ yet.
+We'll dig into this in xref:tagging.adoc[Tagging].

--- a/doc/tagging.adoc
+++ b/doc/tagging.adoc
@@ -1,92 +1,157 @@
 = Tagging
 
-Tags are used in Polylith to mark points in time when we consider the whole codebase (workspace) to be in a valid state, for example that everything compiles
-and that all the tests and the xref:commands.adoc#check[check] command executes without errors.
-This is then used by the xref:commands.adoc#test[test] command to run the tests incrementally, by only executing the affected tests, which substantially speeds up the tests.
+We touched on the concept of a _stable point in time_ in our xref:git.adoc[Git] docs.
+Now, we'll show how we use git tagging to mark and move a workspace's _stable point in time_.
 
-The way we mark a stable point in time is to tag it with git (`-f` tells git to reuse the tag if already exists):
+We consider a workspace stable when the whole workspace is in a valid state.
+For example, when all code compiles, all tests pass, and the xref:commands.adoc#check[check] command executes without error.
+
+The xref:commands.adoc[test] command leverages the concept of stability to support running tests incrementally.
+It can reduce a test run to only those tests affected by changes since the last known _stable point in time_.
+As you can imagine, skipping unnecessary tests can significantly reduce test run times!
+
+To mark a _stable point in time_, we use a git tag.
+
+Let's continue with our xref:introduction.adoc[tutorial].
+We last left off by xref:git.adoc#add-and-commit[adding and committing our workspace files to git].
+
+Mark your `example` workspace as stable by tagging it with git:
 
 [source,shell]
 ----
-git tag -f stable-lisa
+git tag -f stable-lisa # <1>
 ----
+<1> `-f` tells git to move the tag if it already exists
 
-image::images/tagging/info-01.png[width=400]
-
-If we now run `git log --pretty=oneline` again:
+Run `git log --pretty=format'%h %d%n %s`, you'll see something like:
 
 [source,shell]
 ----
-e7ebe683a775ec28b7c2b5d77e01e79d48149d13 (HEAD -> main, tag: stable-lisa) Created the user and cli bricks.
-c91fdad4a34927d9aacfe4b04ea2f304f3303282 Workspace created.
+e7ebe68  (HEAD -> main, tag: stable-lisa)  # <1>
+ Created the user and cli bricks.
+c91fdad
+ Workspace created.
 ----
+<1> Notice the `stable-lisa` tag you added is on the second commit.
 
-...we can see that the second commit has been tagged with `stable-lisa`.
-Note that your hash tags will be different and when we refer to e.g. `c91fdad` in the following examples, you should instead give your own corresponding hash code.
+NOTE: We used `git log --pretty=format'%h %d%n %s` for compact documentation-friendly output.
+Feel free to use `git log --pretty=oneline` or even `git log`.
 
-If we execute the xref:commands.adoc#info[info] command:
+Rerun the `poly xref:commands.adoc#info[info]` command, and you'll see something like this:
 
 image::images/tagging/info-01.png[width=400]
 
-...the `stable since` hash has been updated and is now tagged with `stable-lisa`.
-All the `*` signs are gone because no component, base or project has yet changed since the second commit (which can be verified by running `poly diff` again).
+****
+Remember that git hashes (SHAs and short-SHAs) are globally unique.
+Yours will differ from our `e7ebe68` and `c91fdad`.
+****
 
-We added the tag `stable-lisa` but we could have named the tag with anything that starts with `stable-`.
-We choose `stable-lisa` because Lisa is our name (let's pretend that at least!).
-The idea is that every developer could use their own unique tag name that doesn't conflict with other developers.
+Notice that:
 
-The CI build should also use its own pattern, like `stable-` plus branch name or build number, to mark successful builds.
-It may be enough to only use the stable points that the CI server creates.
-That is at least a good way to start out and only add custom tags per developer when needed.
+* The `stable since` line shows:
+** A short-SHA `e7ebe68` that matches the second commit.
+** The `stable-lisa` tag.
+* All the `*` (asterisk) markers xref:git.adoc#info-all-changed-example[you saw in the previous info output] are gone because no brick (component or base) or project has changed since our new _stable point in time_.
 
-The pattern is configured in `workspace.edn` and can be changed if we prefer something else:
+Run `poly diff`; you'll see no output because nothing has changed.
+
+Our example uses the git tag `stable-lisa`, but `poly` recognizes any tag that starts with `stable-`.
+We chose `stable-lisa` because Lisa is our name (let's pretend, at least!).
+This convention allows every developer to have their own unique _stable point in time_.
+
+Your continuous integration (CI) build should use its own unique git tag pattern to mark successful builds (and, therefore, stable workspaces).
+A convention like `stable-` plus branch name or `stable-` plus build number can work nicely.
+
+We recommend that you start with `stable-` tags created by your CI server and add developer-specific `stable-` tags when needed.
+
+We think that git tags that start with `stable-` is a magnificent naming convention, but if you really prefer something different, you can override this default in your `workspace.edn` file:
 
 [source,clojure]
 ----
- :tag-patterns {:stable "stable-*"
+ :tag-patterns {:stable "stable-*" ;; <1>
                 :release "v[0-9]*"}
 ----
+<1> Override the default `stable-*` regular expression to your own convention, if you wish
 
-The way the tool finds the latest tag is to execute this command internally:
+****
+Internally, `poly` finds the _stable point in time_ commit via:
 
 [source,shell]
 ----
 git log --pretty=format:'%H %d'
 ----
 
-Then it uses the first line of the output that matches the regular expression (e.g. `stable-*`) or if no match was found, the first commit in the repository.
+For our current example, this outputs:
+[source,shell]
+----
+e7ebe683a775ec28b7c2b5d77e01e79d48149d13 (HEAD -> master, tag: stable-lisa)
+c91fdad4a34927d9aacfe4b04ea2f304f3303282
+----
 
-Earlier when we changed a project by editing its `deps.edn` file, it got a trailing `*` to indicate that it was changed.
-But what happens if only some of its bricks have changed? Let's try that by adding a comment to the `user.core` namespace:
+The `poly` tool parses the output for the first line that matches the `:stable` tag pattern (by default `stable-*`).
+If it finds no matches, the first commit in the git repository is the _stable point in time_ commit.
+****
+
+You've seen the `info` command xref:git.adoc#info-all-changed-example[output when all bricks and projects have changed] since the _stable point in time_; all bricks and projects showed a trailing `*` (asterisk).
+
+What happens if only some bricks have changed?
+Let's find out.
+Add a comment to the `user.core` namespace by editing `./components/user/src/se/example/user/core.clj`:
 
 // scripts/sections/tagging/user-core-change.clj
 [source,clojure]
 ----
 (ns se.example.user.core)
 
-; hi!
+; hi! ;; <1>
 (defn hello [name]
-      (str "Hello " name "!"))
+  (str "Hello " name "!"))
 ----
+<1> Add a comment line
 
-...and execute the xref:commands.adoc#info[info] command again:
+Run `poly xref:commands.adoc#info[info]` again:
 
 image::images/tagging/info-02.png[width=400]
 
-Now the two projects are marked with a `+` which indicates that the projects themselves are unchanged but that at least one of their bricks has changed.
+As expected, the `user` component now shows a trailing `*`.
+// I was having trouble getting `+` to render so used `&#43;` instead.
+Notice that both `command-line` and `development` projects show a trailing `&#43;`.
+The `&#43;` indicates the projects have no changes, but at least one of their bricks has changed.
 
 == Release
 
-When we release, we probably want the CI server to tag the release.
-Here we tag the first commit as `v1.1.0` and the second as `v1.2.0` (make sure you replace `c91fdad` with your corresponding sha):
+When you release, we recommend your CI server git tag the release.
+But here, we'll have you experiment from your command line shell.
+
+Run `git log --pretty=format'%h %d%n %s` to look at your current commit history and tags:
+
+[source, shell]
+----
+e7ebe68  (HEAD -> master, tag: stable-lisa)
+ Created the user and cli bricks.
+c91fdad
+ Workspace created.
+----
+
+Tag the first commit as `v1.1.0` and the second as `v1.2.0`:
 
 [source,shell]
 ----
-git tag v1.1.0 c91fdad
+git tag v1.1.0 c91fdad # <1>
 git tag v1.2.0
 ----
+<1> replace `c91fdad` with your corresponding SHA for your first commit
 
-If we execute:
+Rerun `git log --pretty=format'%h %d%n %s` to verify your new tags:
+[source, shell]
+----
+e7ebe68  (HEAD -> master, tag: v1.2.0, tag: stable-lisa)
+ Created the user and cli bricks.
+c91fdad  (tag: v1.1.0)
+ Workspace created.
+----
+
+Now run `poly info` against your latest release:
 
 [source,shell]
 ----
@@ -95,15 +160,7 @@ poly info since:release
 
 image::images/tagging/info-03.png[width=400]
 
-...it picks the latest release tag that follows the pattern defined in `workspace.edn`:
-
-[source,clojure]
-----
- :tag-patterns {...
-                :release "v[0-9]*"}
-----
-
-If we execute:
+If you execute `poly info` against the previous release:
 
 [source,shell]
 ----
@@ -112,24 +169,32 @@ poly info since:previous-release
 
 image::images/tagging/info-04.png[width=400]
 
-...it picks the second latest release tag.
+The `poly` tool has picked up the second latest release tag.
 
-By executing `git log --pretty=oneline` we can verify that the tags are correctly set:
+The `poly` tool matches release tags as defined by your `workspace.edn`:
 
-[source,shell]
+[source,clojure]
 ----
-e7ebe683a775ec28b7c2b5d77e01e79d48149d13 (HEAD -> main, tag: v1.2.0, tag: stable-lisa) Created the user and cli bricks.
-c91fdad4a34927d9aacfe4b04ea2f304f3303282 (tag: v1.1.0) Workspace created.
+ :tag-patterns {:stable "stable-*"
+                :release "v[0-9]*"} ;; <1>
 ----
+<1> Default regular expression for git `:release` tags is `v[0-9]*`.
 
-The `since` argument is used by the CI server to run all tests since the previous release, e.g.:
+You can use the `since` argument on your CI server to run only the necessary tests since the previous release.
+Unaffected code does not need to be retested.
 
 [source,shell]
 ----
 poly test since:previous-release
 ----
 
-Depending on whether we tag before or after the build, we will choose `release` or `previous-release`.
-If `since` is not given, `stable` will be used by default.
+[TIP]
+====
+You'll use:
 
-Some other variants, like `since:e7ebe68v`, `since:head`, or `since:head~1` are also valid.
+* `since:previous-release` if your release process adds a release tag before your build.
+* `since:release` if it adds a release tag after your build
+====
+
+TIP: If the `since` argument is not specified, `since:stable` is used by default. +
+Other variants, like `since:e7ebe68v`, `since:head`, and `since:head~1` are also valid.

--- a/doc/workspace.adoc
+++ b/doc/workspace.adoc
@@ -135,6 +135,7 @@ my-git-repo-dir
 └── workspace.edn
 ----
 
+[[workspace-root-under-git-root]]
 ...or you create the workspace in a directory under the git repository root by executing e.g.,:
 
 [source,shell]


### PR DESCRIPTION
The Git doc seemed to focus on italicized "stable point in time". It seemed important, so I carried the term through to the Tagging doc.

While walking through Git doc examples, it became obvious to me that I had missed the tutorial step of creating lisa.clj from the Development doc. This was because the step was buried in Cursive setup instructions. I've teased out a Generic Setup section for non Cursive users.

Changed git log cmd in some cases for a less wide and more doc friendly output.

And: a bunch of edits for clarity.