### PR TITLE
Moved the table of changes to its own page

### DIFF
--- a/components/doc/src/polylith/clj/core/doc/navigation/generated.clj
+++ b/components/doc/src/polylith/clj/core/doc/navigation/generated.clj
@@ -71,6 +71,7 @@
    "tools-deps" {}
    "upgrade" {}
    "validations" {}
+   "versions" {}
    "workspace" {}})
 
 (def ws-nav

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -24,7 +24,7 @@
 (def minor 2)
 (def patch 18)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 7) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 8) ;; Increase by one for every snapshot release, or set to 0 if a release.
 (def snapshot? (= SNAPSHOT revision))
 
 (def name-without-rev (str major "." minor "." patch))
@@ -35,8 +35,9 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2023-10-20")
+(def date "2023-10-31")
 
+;; Execute 'poly doc version' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})
 (def test-runner-api-version {:breaking 1, :non-breaking 0})
 (def ws-api-version {:breaking 2, :non-breaking 0})
@@ -57,32 +58,3 @@
             :ws ws-api-version}
            from-version (assoc :from from-version)
            snapshot? (assoc-in [:release :snapshot] snapshot))))
-
-;; ====== Workspace attributes (ws) ======
-;;
-;; ws     release         action    attribute                                                  Description
-;; -----  -------------   -------   -----------------------------------------------------------------------------------------------------------------------
-;; 2.0    0.2.18          added     configs
-;;                        added     bases:BASE:base-deps
-;;                        deleted   version.ws.type                                            Moved out to ws-type.
-;;                        deleted   version.from.ws.type
-;;                        added     version:api
-;;                        added     version:tool
-;;                        added     version:test-runner-api
-;;                        added     version:release:snapshot
-;;                        added     ws-type
-;;                        renamed   interfaces:definitions:DEFINITION:arglist                  Renamed from parameters.
-;;                        renamed   projects:PROJECT:deps:BRICK:SOURCE:missing-ifc-and-bases   Renamed from missing-ifc.
-;;                        added     ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:is-ignored
-;;                        added     ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:is-invalid
-;;                        changed   ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:file-path      The ws-dir part is removed from the file path (data change).
-;; 1.2    0.2.16-alpha    added     ENTITIES:ENTITY:namespaces:src:NAMESPACE:invalid
-;; 1.1    0.2.14-alpha    added     settings:vcs:is-git-repo
-;;                        deleted   projects:PROJECT:is-run-tests
-;;
-;; 0.0    0.1.0-alpha9    Version 0.2.0-alpha9 and earlier, has from.ws set to 0.0 if read from file.
-;;
-;; ENTITIES = bases, components, or projects.
-;; ENTITY = a base, component, or project name.
-;; NAMESPACE = a namespace name
-;; SOURCE = src or test.

--- a/doc/cljdoc.edn
+++ b/doc/cljdoc.edn
@@ -41,5 +41,6 @@
                    ["Reference" {}
                     ["Commands" {:file "doc/commands.adoc"}]
                     ["Workspace structure" {:file "doc/workspace-structure.adoc"}]]
+                   ["Versions" {:file "doc/versions.adoc"}]
                    ["Contact" {:file "doc/contact.adoc"}]
                    ["License" {:file "doc/license.adoc"}]]}

--- a/doc/versions.adoc
+++ b/doc/versions.adoc
@@ -1,0 +1,40 @@
+= Versions
+
+There are three areas that are version controlled in Polylith,
+which is described xref:workspace-structure.adoc#version[here].
+
+Here are the changes to the workspace structure over time:
+
+|===
+| ws | release | action | attribute | description
+
+| 2.0 | 0.2.18 | added | configs |
+|  |  | added | bases:BASE:base-deps |
+|  |  | deleted | version.ws.type | Moved out to ws-type.
+|  |  | deleted | version.from.ws.type |
+|  |  | added | version:api |
+|  |  | added | version:tool |
+|  |  | added | version:test-runner-api |
+|  |  | added | version:release:snapshot |
+|  |  | added | ws-type |
+|  |  | renamed | interfaces:definitions:DEFINITION:arglist | Renamed from parameters.
+|  |  | renamed | projects:PROJECT:deps:BRICK:SOURCE:missing-ifc-and-bases | Renamed from missing-ifc.
+|  |  | added | ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:is-ignored |
+|  |  | added | ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:is-invalid |
+|  |  | changed | ENTITIES:ENTITY:namespaces:SOURCE:NAMESPACE:file-path | The ws-dir part is removed from the file path (data change).
+| 1.2 | 0.2.16-alpha | added | ENTITIES:ENTITY:namespaces:src:NAMESPACE:invalid |
+| 1.1 | 0.2.14-alpha | added | settings:vcs:is-git-repo |
+|  |  | deleted | projects:PROJECT:is-run-tests |
+| 0.0 | 0.1.0-alpha9 |  |  | Version 0.2.0-alpha9 and earlier, has from.ws set to 0.0 if read from file.
+|===
+
+Used in the above table:
+
+|===
+| What | Description
+
+| ENTITY | Bases, components, or projects.
+| ENTITIES | Bases, components, or projects.
+| NAMESPACE | A namespace name.
+| SOURCE | src or test.
+|===

--- a/doc/workspace-structure.adoc
+++ b/doc/workspace-structure.adoc
@@ -988,7 +988,7 @@ Each subsequent snapshot release will increase this value by one.
 *** `:breaking` The breaking version of the original `ws` format.
 *** `:non-breaking` The non-breaking version of the original `ws` format.
 
-Changes to the xref:workspace-structure.adoc[workspace structure], is documented in the https://github.com/polyfy/polylith/blob/9053b190d5f3b0680ac4fe5c5f1851f7c0d40830/components/version/src/polylith/clj/core/version/interface.clj#L37-L57[version] component.
+Changes to the xref:workspace-structure.adoc[workspace structure] is documented in the xref:versions.adoc[versions] page.
 
 [#ws-dir]
 == ws-dir


### PR DESCRIPTION
Move the workspace structure changes from the version component to its own page.