### PR TITLE
Review and update Continuous Integration doc

### DIFF
--- a/doc/continuous-integration.adoc
+++ b/doc/continuous-integration.adoc
@@ -1,57 +1,33 @@
 = Continuous Integration
+:toc:
 
-When setting up continuous integration, we sometimes want to keep track of changes per project.
-To support this we need to add tag patterns for the projects we want to build, e.g.:
+The `poly` tool stays out of your way on how you xref:build.adoc[build] your xref:project.adoc[deployable project] xref:artifacts.adoc[artifacts] on your continuous integration server.
 
-[source,clojure]
-----
- :tag-patterns {:stable "stable-*"
-                :release "v[0-9]*"
-                :myproject "myproject-*"}
-----
+Here, we go over a couple of xref:tagging.adoc#release[tagging and release] strategies for you to consider.
 
-When our build is triggered, e.g. via a webhook, we can ask the `poly` tool what projects have changed since the last successful build:
+== Build and Release All
 
+If you don't have many projects, you might want to build and deploy for all deployable projects:
+
+. Run tests.
+. Git tag the release.
+. Build artifacts for all deployable projects.
+. Deploy all built artifacts.
+
+== Build and Release for Changed Projects Only
+
+Perhaps you want to optimize your flow to only build and deploy what has changed:
+
+. Run tests.
+. Ask `poly` what deployable projects have changed since the last release:
++
 [source,shell]
 ----
-poly ws get:changes:changed-or-affected-projects since:myproject
+poly ws get:changes:changed-or-affected-projects since:release skip:dev # <1>
 ----
+<1> We `skip:dev` because it is not a deployable project
+. Git tag the release.
+. Build artifacts for all _changed_ deployable projects.
+. Deploy all built artifacts.
 
-...outputs, e.g.:
-
-[source,clojure]
-----
-["invoicer" "myproject"]
-----
-
-If `myproject` is returned, which is the case here, then we know that this project needs to be built and deployed, as long as all tests also pass.
-After a successful build, we can tag the repository with e.g.:
-
-[source,shell]
-----
-git tag myproject-1
-----
-
-We want to keep the release tags, which is the reason each tag gets its own unique tag name, e.g. `myproject-1`, `myproject-2`, and so on.
-It's not important that the IDs are sequential.
-The tool will always sort them by the order they exist in git anyway.
-
-If the CI build is set up so that it builds all projects in one go, then we could first start by asking what projects we have:
-
-[source,shell]
-----
-poly ws get:projects:keys skip:dev
-----
-
-The `skip:dev` argument tells the tool to ignore the `development` project
-(we are not interested in deploying that project).
-More than one project can be ignored, e.g. `skip:dev:invoicer`, where both project names and aliases can be used.
-
-Then we can ask for changed or affected projects:
-
-[source,shell]
-----
-poly ws get:changes:changed-or-affected-projects since:release skip:dev
-----
-
-This will list all projects that need to be deployed since the latest tag that matches `release-*`.
+If you were to swap steps 2 and 3, you would use `since:previous-release` instead of `since:release`

--- a/doc/tagging.adoc
+++ b/doc/tagging.adoc
@@ -119,6 +119,7 @@ As expected, the `user` component now shows a trailing `*`.
 Notice that both `command-line` and `development` projects show a trailing `&#43;`.
 The `&#43;` indicates the projects have no changes, but at least one of their bricks has changed.
 
+[[release]]
 == Release
 
 When you release, we recommend your CI server git tag the release.
@@ -199,3 +200,5 @@ You'll use:
 
 TIP: If the `since` argument is not specified, `since:stable` is used by default. +
 Other variants, like `since:e7ebe68v`, `since:head`, and `since:head~1` are also valid.
+
+See xref:continuous-integration.adoc[Continuous Integration] for tagging and release strategies.


### PR DESCRIPTION
After me discussing with Joakim and then he with Sean, we found that tracking per project did not make sense. So it that content has been turfed.

Described 2 simple tagging/release strategies for readers to consider.