### PR TITLE
Fix CI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
 
             if [[ "$VERSION" == *-SNAPSHOT ]]; then
               STABLE_TAG="stable-$CIRCLE_BRANCH"
-              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" -replace -prerelease ${STABLE_TAG} ./artifacts
+              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" -replace -prerelease -recreate ${STABLE_TAG} ./artifacts
             else
               VERSION_TAG="v$VERSION"
               ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" ${VERSION_TAG} ./artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,8 +143,11 @@ jobs:
           command: |
             TAG_NAME="stable-$CIRCLE_BRANCH"
 
-            git tag -d ${TAG_NAME}
-            git push origin --delete ${TAG_NAME}
+            if git rev-parse -q --verify "refs/tags/${TAG_NAME}" > /dev/null; then
+              git tag -d ${TAG_NAME}
+              git push origin --delete ${TAG_NAME}
+            fi
+
             git tag ${TAG_NAME} -m "[skip ci] Added Stable Polylith tag"
             git push origin ${TAG_NAME}
   add-version-tag:
@@ -173,8 +176,11 @@ jobs:
             else
               TAG_NAME="v$VERSION"
 
-              git tag -d ${TAG_NAME}
-              git push origin --delete ${TAG_NAME}
+              if git rev-parse -q --verify "refs/tags/${TAG_NAME}" > /dev/null; then
+                git tag -d ${TAG_NAME}
+                git push origin --delete ${TAG_NAME}
+              fi
+
               git tag ${TAG_NAME} -m "[skip ci] Added new version tag"
               git push origin ${TAG_NAME}
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,12 +177,11 @@ jobs:
               TAG_NAME="v$VERSION"
 
               if git rev-parse -q --verify "refs/tags/${TAG_NAME}" > /dev/null; then
-                git tag -d ${TAG_NAME}
-                git push origin --delete ${TAG_NAME}
+                echo "Skip adding tag. Reason: Already deployed this version before"
+              else
+                git tag ${TAG_NAME} -m "[skip ci] Added new version tag"
+                git push origin ${TAG_NAME}
               fi
-
-              git tag ${TAG_NAME} -m "[skip ci] Added new version tag"
-              git push origin ${TAG_NAME}
             fi
   deploy:
     docker:
@@ -201,7 +200,13 @@ jobs:
             if [[ "$VERSION" == *-SNAPSHOT ]]; then
               clojure -T:build deploy-snapshot
             else
-              clojure -T:build deploy
+              TAG_NAME="v$VERSION"
+
+              if git rev-parse -q --verify "refs/tags/${TAG_NAME}" > /dev/null; then
+                echo "Skip deploying. Reason: Already deployed this version before"
+              else
+                clojure -T:build deploy
+              fi
             fi
   create-artifacts:
     docker:
@@ -238,7 +243,7 @@ jobs:
               ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" -replace -prerelease -recreate ${STABLE_TAG} ./artifacts
             else
               VERSION_TAG="v$VERSION"
-              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" ${VERSION_TAG} ./artifacts
+              ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n "Version ${VERSION}" -soft ${VERSION_TAG} ./artifacts
             fi
 
 workflows:


### PR DESCRIPTION
This PR addresses several issues:

### 1. Do not fail deployment if tag does not exists
The CI script tried deleting the git tag before creating it. This is useful for `stable-*` tags but caused a problem when releasing a new version since the new version tag will not exist.

### 2. Replace pre-releases
Every pre-release commit to master branch created a new pre-release version on GitHub. Instead, we can replace the existing one, until the actual release. The [ghr](https://github.com/tcnksm/ghr) command we use in the deployment script has an option called `-recreate` to enable this and I've added it here:
https://github.com/polyfy/polylith/blob/9402e53e1797aa2c6450a1ee677d8a0b725e1daa/.circleci/config.yml#L243

### 3. CI should not try deploying on master branch if the version number is already deployed before
Right now, CI is trying and failing to deploy if the current version on master is a REVISION and the version number is not updated. We should just simply skip the deployment instead of causing trouble. This will also allow us to merge some commits to the master branch without releasing a version (like this PR, we do not want to release a version for CI changes).



