### PR TITLE
Fixed link to cljdoc 0.2.18.

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,7 +1,7 @@
 image::doc/images/logo.png[width=400]
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc
 
-https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc/readme[image:https://badgen.net/badge/doc/0.2.18/blue[]]
+https://cljdoc.org/d/polylith/clj-poly/0.2.18/doc/readme[image:https://badgen.net/badge/doc/0.2.18/blue[]]
 ifdef::env-cljdoc[]
 https://cljdoc.org/d/polylith/clj-poly/0.2.19-SNAPSHOT[image:https://badgen.net/badge/doc/0.2.19-SNAPSHOT/cyan[]]
 endif::[]


### PR DESCRIPTION
Fix link on the starting page in cljdoc.