### PR TITLE
Don't show the size of a library if :hide-lib-size is passed in

### DIFF
--- a/components/command/src/polylith/clj/core/command/core.clj
+++ b/components/command/src/polylith/clj/core/command/core.clj
@@ -1,6 +1,5 @@
 (ns ^:no-doc polylith.clj.core.command.core
   (:require [clojure.string :as str]
-            [polylith.clj.core.change.interface :as change]
             [polylith.clj.core.check.interface :as check]
             [polylith.clj.core.command.cmd-validator.core :as cmd-validator]
             [polylith.clj.core.command.create :as create]
@@ -20,7 +19,6 @@
             [polylith.clj.core.util.interface.color :as color]
             [polylith.clj.core.version.interface :as ver]
             [polylith.clj.core.workspace.interface :as workspace]
-            [polylith.clj.core.ws-file.interface :as ws-file]
             [polylith.clj.core.ws-explorer.interface :as ws-explorer])
   (:refer-clojure :exclude [test]))
 
@@ -71,7 +69,7 @@
   (println (str "  The use of :: is " (color/error color-mode "deprecated") " and support for it will probably be dropped in the future. "
                 "Please contact the Polylith team if you think it's important to keep!")))
 
-(defn execute [{:keys [cmd args alias name top-ns branch help is-local more page ws is-tap is-git-add is-github is-commit is-update is-show-brick is-show-workspace is-show-project is-verbose is-fake-poly is-search-for-ws-dir get out interface selected-bricks selected-projects unnamed-args ws-file] :as user-input}]
+(defn execute [{:keys [cmd args alias name top-ns branch help is-local more page ws is-tap is-git-add is-github is-commit is-update is-show-brick is-show-workspace is-show-project is-verbose is-fake-poly is-search-for-ws-dir get out interface selected-bricks selected-projects unnamed-args] :as user-input}]
   (let [color-mode (common/color-mode user-input)
         ws-dir (config-reader/workspace-dir user-input)
         workspace (workspace/workspace user-input)

--- a/components/lib/src/polylith/clj/core/lib/text_table/lib_table.clj
+++ b/components/lib/src/polylith/clj/core/lib/text_table/lib_table.clj
@@ -42,18 +42,19 @@
           (map-indexed #(lib-cell 7 (+ 3 %1) %2)
                        (map :type libraries))))
 
-(defn size-kb [{:keys [size]} thousand-separator]
-  (if (nil? size)
+(defn size-kb [{:keys [size]} thousand-separator hide-lib-size?]
+  (if (or (nil? size)
+          hide-lib-size?)
     "-"
     (str-util/sep-1000 (quot size 1024) thousand-separator)))
 
-(defn kb-cell [row library thousand-separator]
-  (let [size (size-kb library thousand-separator)]
+(defn kb-cell [row library thousand-separator hide-lib-size?]
+  (let [size (size-kb library thousand-separator hide-lib-size?)]
     (text-table/cell 9 row size :none :right :horizontal)))
 
-(defn size-column [libraries thousand-separator]
+(defn size-column [libraries thousand-separator hide-lib-size?]
   (concat [(text-table/cell 9 1 "KB" :none :right :horizontal)]
-          (map-indexed #(kb-cell (+ 3 %1) %2 thousand-separator)
+          (map-indexed #(kb-cell (+ 3 %1) %2 thousand-separator hide-lib-size?)
                        libraries)))
 
 (defn flag-cell [column row lib-dep src-deps test-deps]
@@ -115,7 +116,7 @@
 
 (defn table [{:keys [configs settings user-input profiles components bases projects] :as workspace}]
   (let [{:keys [empty-character thousand-separator color-mode]} settings
-        is-outdated (:is-outdated user-input)
+        {:keys [is-outdated is-hide-lib-size]} user-input
         calculate-latest-version? (common/calculate-latest-version? user-input)
         lib->latest-version (antq/library->latest-version configs calculate-latest-version?)
         entities (concat components bases projects)
@@ -131,7 +132,7 @@
         version-col (version-column libraries)
         latest-col (when is-outdated (latest-column libraries lib->latest-version))
         type-col (type-column libraries)
-        size-col (size-column libraries thousand-separator)
+        size-col (size-column libraries thousand-separator is-hide-lib-size)
         project-cols (project-columns libraries projects)
         n#dev (count (filter :is-dev projects))
         n#projects (- (count projects) n#dev)
@@ -164,5 +165,6 @@
 (comment
   (require '[dev.jocke :as dev])
   (print-table dev/workspace)
-  (print-table (assoc-in dev/workspace [:user-input :is-outdated] true))§
+  (print-table (assoc-in dev/workspace [:user-input :is-hide-lib-size] true))
+  (print-table (assoc-in dev/workspace [:user-input :is-outdated] true))
   #__)

--- a/components/shell/src/polylith/clj/core/shell/candidate/specification.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/specification.clj
@@ -131,6 +131,7 @@
 ;; libs
 (def libs-outdated (c/flag "outdated" :libs))
 (def libs-update (c/flag "update" :libs))
+(def libs-hide-lib-size (c/flag "hide-lib-size" :libs))
 (def libs-libraries (c/fn-explorer "libraries" :libs #'outdated-libs/select))
 (def libs-out (c/fn-explorer "out" :libs (file-explorer/select-fn)))
 (def libs-skip (c/fn-explorer "skip" :libs #'ws-projects/select))
@@ -139,7 +140,7 @@
 (defn libs [all? extended?]
   (c/single-txt "libs" :libs
     (concat [libs-outdated libs-update libs-libraries]
-            (when all? [compact libs-skip libs-color-mode])
+            (when all? [compact libs-skip libs-hide-lib-size libs-color-mode])
             (when (or all? extended?) [libs-out]))))
 
 ;; test

--- a/components/user-input/src/polylith/clj/core/user_input/core.clj
+++ b/components/user-input/src/polylith/clj/core/user_input/core.clj
@@ -76,6 +76,7 @@
                 git-add!
                 github!
                 help
+                hide-lib-size!
                 interface
                 latest-sha!
                 libraries
@@ -126,6 +127,7 @@
                       :is-fake-poly (= "true" fake-poly!)
                       :is-git-add (when git-add! (= "true" git-add!))
                       :is-github (= "true" github!)
+                      :is-hide-lib-size (= "true" hide-lib-size!)
                       :is-latest-sha (= "true" latest-sha!)
                       :is-local (= "true" local!)
                       :is-no-changes (= "true" no-changes!)

--- a/doc/developing-poly.adoc
+++ b/doc/developing-poly.adoc
@@ -114,6 +114,17 @@ polyx :fake-poly # <2>
 
 This can be handy when capturing output for docs.
 
+=== `hide-lib-size`
+
+If `:hide-lib-size` is given to the xref:commands.adoc#libs[libs] command, values in the `KB` column appear as `-`:
+
+[source,shell]
+----
+poly libs :hide-lib-size # <1>
+----
+
+This is used in tests to guarantee that the output will look the same, regardless if a library has been downloaded or not.
+
 === `latest-sha`
 
 Populate the `latest-sha` from your Git repository in your workspace structure (by default, `poly` does not populate this value).

--- a/doc/workspace-structure.adoc
+++ b/doc/workspace-structure.adoc
@@ -789,6 +789,7 @@ poly ws get:user-input
  :is-dev false
  :is-fake-poly false
  :is-github false
+ :is-hide-lib-size false
  :is-latest-sha false
  :is-local false
  :is-no-changes false
@@ -886,6 +887,8 @@ Has the same effect for current command as if `:vcs > :auto-add` was set to `tru
 
 * `:is-github` Set to `true` if `:github` is given.
 Used by the xref:commands.adoc#doc[doc] command to open the corresponding page on GitHub.
+
+* `:is-hide-lib-size` Set to `true` if `:is-hide-lib-size` is given. Used by the tests to show `-` instead the of size of the libraries in the `libs` command, to protect tests from failing if a library hasn't been downloaded yet.
 
 * `:is-latest-sha` Set to `true` if `:latest-sha` is given.
 

--- a/next-release.adoc
+++ b/next-release.adoc
@@ -20,6 +20,8 @@
 
 | New https://github.com/polyfy/polylith/blob/master/examples/poly-rcf/readme.md[poly-rcf] example workspace that shows how to run [Hyperfiddle rcf](https://github.com/hyperfiddle/rcf) tests with the `poly` tool.
 
+| If `:hide-lib-size` is given to the `libs` command, values in the `KB` column appear as `-`.
+
 |===
 
 |===

--- a/projects/poly/test/project/poly/poly_workspace_test.clj
+++ b/projects/poly/test/project/poly/poly_workspace_test.clj
@@ -187,7 +187,7 @@
           "  change                    .  .  .  .  x  .  .  .  .  .  x  .  .  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  ."
           "  check                     .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  .  .  ."
           "  clojure-test-test-runner  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  x  .  .  .  .  ."
-          "  command                   .  x  x  .  x  x  x  x  x  x  x  x  .  x  x  .  x  .  .  x  .  x  .  .  .  x  .  x  .  x  .  x  x  x  x"
+          "  command                   .  .  x  .  x  x  x  x  x  x  x  x  .  x  x  .  x  .  .  x  .  x  .  .  .  x  .  x  .  x  .  x  x  x  ."
           "  common                    .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  x  .  x  .  .  ."
           "  config-reader             .  .  .  .  x  .  .  .  .  x  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  x  .  .  .  ."
           "  creator                   .  .  .  .  x  .  .  .  .  x  x  .  .  .  .  .  .  .  .  .  .  .  .  t  .  .  .  .  .  x  .  x  .  .  ."
@@ -259,7 +259,7 @@
             "  change                    .  .  .  .  x  .  .  .  .  +  x  .  +  .  .  .  .  x  +  .  +  .  .  .  .  .  +  +  .  x  .  +  .  .  ."
             "  check                     .  .  .  .  +  .  .  +  .  +  .  .  +  .  .  .  .  +  .  .  +  .  .  .  +  .  +  +  .  x  x  +  .  .  ."
             "  clojure-test-test-runner  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  x  .  .  .  .  ."
-            "  command                   +  x  x  .  x  x  x  x  x  x  x  x  +  x  x  +  x  +  +  x  +  x  +  .  +  x  +  x  +  x  +  x  x  x  x"
+            "  command                   +  +  x  .  x  x  x  x  x  x  x  x  +  x  x  +  x  +  +  x  +  x  +  .  +  x  +  x  +  x  +  x  x  x  +"
             "  common                    .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  .  .  +  .  .  .  .  .  x  x  .  x  .  x  .  .  ."
             "  config-reader             .  .  .  .  x  .  .  +  .  x  .  .  +  .  .  .  .  +  .  .  +  .  .  .  +  .  +  +  .  x  x  +  .  .  ."
             "  creator                   -  -  -  -  x  -  -  -  -  x  x  -  +  -  -  -  -  -  +  -  +  -  -  t  -  -  +  +  -  x  -  x  -  -  -"
@@ -329,7 +329,7 @@
             "  change                    .  .  .  .  x  .  .  .  .  +  x  .  +  .  .  .  .  x  +  .  +  .  .  .  .  .  +  +  .  x  .  +  .  .  ."
             "  check                     .  .  .  .  +  .  .  +  .  +  .  .  +  .  .  .  .  +  .  .  +  .  .  .  +  .  +  +  .  x  x  +  .  .  ."
             "  clojure-test-test-runner  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  .  x  .  .  .  .  x  .  .  .  .  ."
-            "  command                   +  x  x  .  x  x  x  x  x  x  x  x  +  x  x  +  x  +  +  x  +  x  +  .  +  x  +  x  +  x  +  x  x  x  x"
+            "  command                   +  +  x  .  x  x  x  x  x  x  x  x  +  x  x  +  x  +  +  x  +  x  +  .  +  x  +  x  +  x  +  x  x  x  +"
             "  common                    .  .  .  .  .  .  .  .  .  x  .  .  x  .  .  .  .  .  .  .  +  .  .  .  .  .  x  x  .  x  .  x  .  .  ."
             "  config-reader             .  .  .  .  x  .  .  +  .  x  .  .  +  .  .  .  .  +  .  .  +  .  .  .  +  .  +  +  .  x  x  +  .  .  ."
             "  creator                   -  -  -  -  x  -  -  -  -  x  x  -  +  -  -  -  -  -  +  -  +  -  -  t  -  -  +  +  -  x  -  x  -  -  -"
@@ -482,8 +482,7 @@
                                                       "util"]}
                                       :test {:direct ["test-runner-contract"
                                                       "util"]}}
-          "command"                  {:src  {:direct   ["change"
-                                                        "check"
+          "command"                  {:src  {:direct   ["check"
                                                         "common"
                                                         "config-reader"
                                                         "creator"
@@ -502,9 +501,9 @@
                                                         "util"
                                                         "version"
                                                         "workspace"
-                                                        "ws-explorer"
-                                                        "ws-file"]
+                                                        "ws-explorer"]
                                              :indirect ["antq"
+                                                        "change"
                                                         "image-creator"
                                                         "maven"
                                                         "path-finder"
@@ -514,9 +513,9 @@
                                                         "test-runner-contract"
                                                         "text-table"
                                                         "user-input"
-                                                        "validator"]}
-                                      :test {:direct   ["change"
-                                                        "check"
+                                                        "validator"
+                                                        "ws-file"]}
+                                      :test {:direct   ["check"
                                                         "common"
                                                         "config-reader"
                                                         "creator"
@@ -535,9 +534,9 @@
                                                         "util"
                                                         "version"
                                                         "workspace"
-                                                        "ws-explorer"
-                                                        "ws-file"]
+                                                        "ws-explorer"]
                                              :indirect ["antq"
+                                                        "change"
                                                         "image-creator"
                                                         "maven"
                                                         "path-finder"
@@ -547,7 +546,8 @@
                                                         "test-runner-contract"
                                                         "text-table"
                                                         "user-input"
-                                                        "validator"]}}
+                                                        "validator"
+                                                        "ws-file"]}}
           "common"                   {:src  {:direct   ["file"
                                                         "image-creator"
                                                         "text-table"
@@ -1396,44 +1396,44 @@
                   "deps" "project:s" "brick:database1"))))
 
 (deftest profile-libs
-  (is (= ["                                                                         t"
-          "                                                                         e"
-          "                                                                         s"
-          "                                                                         t"
-          "                                                                         -"
-          "                                                                         h"
-          "                                                                         e"
-          "                                                                         l"
-          "                                                                         p"
-          "                                                                         e"
-          "                                                                         r"
-          "  library              version  type      KB   s   dev  default  extra   1"
-          "  ------------------------------------------   -   -------------------   -"
-          "  clj-commons/fs       1.6.310  maven     12   -    -      x       -     ."
-          "  metosin/malli        0.14.0   maven     88   t    x      -       -     x"
-          "  org.clojure/clojure  1.11.1   maven  4,008   x    x      -       -     ."]
+  (is (= ["                                                                      t"
+          "                                                                      e"
+          "                                                                      s"
+          "                                                                      t"
+          "                                                                      -"
+          "                                                                      h"
+          "                                                                      e"
+          "                                                                      l"
+          "                                                                      p"
+          "                                                                      e"
+          "                                                                      r"
+          "  library              version  type   KB   s   dev  default  extra   1"
+          "  ---------------------------------------   -   -------------------   -"
+          "  clj-commons/fs       1.6.310  maven   -   -    -      x       -     ."
+          "  metosin/malli        0.14.0   maven   -   t    x      -       -     x"
+          "  org.clojure/clojure  1.11.1   maven   -   x    x      -       -     ."]
          (run-cmd "examples/profiles"
-                  "libs"))))
+                  "libs" ":hide-lib-size"))))
 
 (deftest profile-libs-skip-dev
-  (is (= ["                                                   t"
-          "                                                   e"
-          "                                                   s"
-          "                                                   t"
-          "                                                   -"
-          "                                                   h"
-          "                                                   e"
-          "                                                   l"
-          "                                                   p"
-          "                                                   e"
-          "                                                   r"
-          "  library              version  type      KB   s   1"
-          "  ------------------------------------------   -   -"
-          "  clj-commons/fs       1.6.310  maven     12   -   ."
-          "  metosin/malli        0.14.0   maven     88   t   x"
-          "  org.clojure/clojure  1.11.1   maven  4,008   x   ."]
+  (is (= ["                                                t"
+          "                                                e"
+          "                                                s"
+          "                                                t"
+          "                                                -"
+          "                                                h"
+          "                                                e"
+          "                                                l"
+          "                                                p"
+          "                                                e"
+          "                                                r"
+          "  library              version  type   KB   s   1"
+          "  ---------------------------------------   -   -"
+          "  clj-commons/fs       1.6.310  maven   -   -   ."
+          "  metosin/malli        0.14.0   maven   -   t   x"
+          "  org.clojure/clojure  1.11.1   maven   -   x   ."]
          (run-cmd "examples/profiles"
-                  "libs" "skip:dev"))))
+                  "libs" "skip:dev" ":hide-lib-size"))))
 
 (deftest test-runner-inherit-test-runner-from-global
   (is (= ["{:create-test-runner"


### PR DESCRIPTION
Don't show the size of a library if :hide-lib-size is passed in. This is used when testing the libs command, to make sure that the output looks the same, regardless if a library has been downloaded or not.