### PR TITLE
Exclude namespaces from the API

### DIFF
--- a/components/test/src/polylith/clj/core/test/core.clj
+++ b/components/test/src/polylith/clj/core/test/core.clj
@@ -8,7 +8,7 @@
   (assoc project :bricks-to-test []
                  :projects-to-test []))
 
-(defn with-test-calculations [{:keys [ws-dir user-input projects paths changes] :as workspace}]
+(defn with-to-test [{:keys [ws-dir user-input projects paths changes] :as workspace}]
   (if (common/invalid-workspace? workspace)
     workspace
     (if (-> ws-dir git/is-git-repo? not)

--- a/components/test/src/polylith/clj/core/test/interface.clj
+++ b/components/test/src/polylith/clj/core/test/interface.clj
@@ -1,7 +1,7 @@
 (ns ^:no-doc polylith.clj.core.test.interface
   (:require [polylith.clj.core.test.core :as core]))
 
-(defn with-test-calculations
+(defn with-to-test
   "Make sure to first call changes/with-changes before calling this function."
   [workspace]
-  (core/with-test-calculations workspace))
+  (core/with-to-test workspace))

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,8 +25,8 @@
 (def minor 2)
 (def patch 20)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 9) ;; Increase by one for every snapshot release, or set to 0 if a release.
-                 ;; Also update :snapshot-version: at the top of readme.adoc.
+(def snapshot 10) ;; Increase by one for every snapshot release, or set to 0 if a release.
+                  ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 
 (def name-without-rev (str major "." minor "." patch))
@@ -37,7 +37,7 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2024-03-17")
+(def date "2024-03-18")
 
 ;; Execute 'poly doc version' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})

--- a/components/workspace/src/polylith/clj/core/workspace/core.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/core.clj
@@ -14,7 +14,7 @@
         (-> workspace
             (enrich/enrich-workspace workspaces)
             (change/with-changes)
-            (test/with-test-calculations))))))
+            (test/with-to-test))))))
 
 (comment
   (require '[polylith.clj.core.user-input.interface :as user-input])

--- a/components/workspace/src/polylith/clj/core/workspace/external/fromdisk.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/external/fromdisk.clj
@@ -1,4 +1,4 @@
-(ns polylith.clj.core.workspace.external.fromdisk
+(ns ^:no-doc polylith.clj.core.workspace.external.fromdisk
   (:require [clojure.string :as str]
             [polylith.clj.core.change.interface :as change]
             [polylith.clj.core.file.interface :as file]

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 image::doc/images/logo.png[width=400]
-:snapshot-version: 9
+:snapshot-version: 10
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc
 
 https://cljdoc.org/d/polylith/clj-poly/0.2.19/doc/readme[image:https://badgen.net/badge/doc/0.2.19/blue[]]


### PR DESCRIPTION
Remove a namespace from the clj-poly library API, that was mistakenly added.