### PR TITLE
Fix :keep-lib-versions for components

### DIFF
--- a/components/lib/src/polylith/clj/core/lib/antq/outdated.clj
+++ b/components/lib/src/polylith/clj/core/lib/antq/outdated.clj
@@ -1,8 +1,9 @@
 (ns ^:no-doc polylith.clj.core.lib.antq.outdated)
 
-(defn library-selected?
-  "Check if the library is in the set of libraries, if passed in by libraries:LIB1:LIB2.
-   If not passed in, it's empty, and we consider it as selected."
+(defn library-selected-for-update?
+  "Check if the library is in the set of libraries that we want to update,
+  if passed in by libraries:LIB1:LIB2. If not passed in, it's empty,
+  and we consider it as selected."
   [lib-name selected-libs]
   (or (empty? selected-libs)
       (contains? selected-libs lib-name)))
@@ -18,11 +19,11 @@
    If the library doesn't exist in that vector for a brick or project, then
    it's fine to update the library."
   [lib-name entity-name entity-type name-type->keep-lib-versions]
-  (not (contains? (set (get name-type->keep-lib-versions [entity-name entity-type]))
+  (not (contains? (get name-type->keep-lib-versions [entity-name entity-type])
                   lib-name)))
 
 (defn update-lib-version? [entity-name entity-type lib-name lib-def selected-libs lib->latest-version name-type->keep-lib-versions]
-  (and (library-selected? lib-name selected-libs)
+  (and (library-selected-for-update? lib-name selected-libs)
        (old-library-version? lib-def lib-name lib->latest-version)
        (update-library? lib-name entity-name entity-type name-type->keep-lib-versions)))
 

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,7 +25,7 @@
 (def minor 2)
 (def patch 20)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 19) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 20) ;; Increase by one for every snapshot release, or set to 0 if a release.
                   ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 
@@ -37,7 +37,7 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2024-05-31")
+(def date "2024-06-01")
 
 ;; Execute 'poly doc version' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})

--- a/components/workspace/src/polylith/clj/core/workspace/enrich/core.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/enrich/core.clj
@@ -38,7 +38,7 @@
 (defn ->name-type->keep-lib-versions [bases components projects]
   (into {}
         (mapv (juxt #(vector (:name %) (:type %))
-                    #(map str (:keep-lib-versions %)))
+                    #(set (map str (:keep-lib-versions %))))
               (concat bases components projects))))
 
 (defn enrich-workspace [{:keys [alias ws-dir user-input settings configs components bases profiles config-errors projects paths] :as workspace}

--- a/components/workspace/src/polylith/clj/core/workspace/fromdisk/components_from_disk.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/fromdisk/components_from_disk.clj
@@ -27,7 +27,6 @@
         lib-deps (lib/brick-lib-deps ws-dir ws-type deps-config top-namespace ns-to-lib namespaces entity-root-path user-home)
         paths (brick-paths/source-paths component-dir deps-config)
         source-paths (config/source-paths deps-config)
-        component-settings (get brick->settings component-name)
         non-top-namespaces (non-top-ns/non-top-namespaces "component" component-name component-dir top-src-dir source-paths)]
     (util/ordered-map :name component-name
                       :type "component"
@@ -36,9 +35,9 @@
                       :namespaces namespaces
                       :non-top-namespaces non-top-namespaces
                       :lib-deps lib-deps
-                      :test (get-in component-settings [component-name :test])
-                      :necessary (get-in component-settings [component-name :necessary])
-                      :keep-lib-versions (get-in component-settings [component-name :keep-lib-versions])
+                      :test (get-in brick->settings [component-name :test])
+                      :necessary (get-in brick->settings [component-name :necessary])
+                      :keep-lib-versions (get-in brick->settings [component-name :keep-lib-versions])
                       :interface (util/ordered-map :name interface-name
                                                    :definitions definitions))))
 

--- a/next-release.adoc
+++ b/next-release.adoc
@@ -11,7 +11,7 @@
 
 | https://github.com/polyfy/polylith/issues/457[457] | Support snippets of test configuration to be merged into settings
 
-| https://github.com/polyfy/polylith/issues/465[465] | Make sure :keep-lib-versions works when updating libs (bug)
+| https://github.com/polyfy/polylith/issues/465[465] | Make sure :keep-lib-versions works when updating libs for components (bug)
 
 |===
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 image::doc/images/logo.png[width=400]
-:snapshot-version: 19
+:snapshot-version: 20
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc
 
 https://cljdoc.org/d/polylith/clj-poly/0.2.19/doc/readme[image:https://badgen.net/badge/doc/0.2.19/blue[]]


### PR DESCRIPTION
Component configuration from :bricks in workspace.edn was not picked up for components (earlier introduced bug).
issue #465