### PR TITLE
Brick validation

### DIFF
--- a/components/deps/src/polylith/clj/core/deps/brick_deps/core.clj
+++ b/components/deps/src/polylith/clj/core/deps/brick_deps/core.clj
@@ -2,50 +2,63 @@
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]))
 
-(defn brick-dep [brick-id from-ns suffixed-top-ns base-names imported-ns]
+(defn brick-dep [brick-id from-type from-ns suffixed-top-ns interface-names base-names imported-ns]
   (let [{:keys [root-ns depends-on-ns]} (common/extract-namespace suffixed-top-ns imported-ns)
-        type (if (contains? base-names root-ns) "base" "component")]
+        type (cond
+               (contains? base-names root-ns) "base"
+               (contains? interface-names root-ns) "interface"
+               :library "library")]
     (when (and root-ns
                (not= brick-id root-ns))
-      {:to-brick-id root-ns
+      {:from-type from-type
        :from-ns from-ns
        :to-type type
+       :to-brick-id root-ns
        :to-namespace depends-on-ns})))
 
-(defn brick-ns-import-deps [brick-id suffixed-top-ns base-names {:keys [name imports]}]
-  (map #(brick-dep brick-id name suffixed-top-ns base-names (str %))
+(defn brick-ns-import-deps [brick-id type suffixed-top-ns interface-names base-names {:keys [name imports]}]
+  (map #(brick-dep brick-id type name suffixed-top-ns interface-names base-names (str %))
        imports))
 
-(defn brick-ns-deps [brick-id suffixed-top-ns base-names namespaces]
-  (vec (mapcat #(brick-ns-import-deps brick-id suffixed-top-ns base-names %)
+(defn brick-ns-deps [brick-id type suffixed-top-ns interface-names base-names namespaces]
+  (vec (mapcat #(brick-ns-import-deps brick-id type suffixed-top-ns interface-names base-names %)
                namespaces)))
 
-(defn brick-deps-for-source [suffixed-top-ns {:keys [name interface namespaces]} base-names source]
+(defn brick-deps-for-source [suffixed-top-ns {:keys [name type interface namespaces]} interface-names base-names source]
   (let [brick-id (or (:name interface) name)]
     (filter :to-brick-id
-            (brick-ns-deps brick-id suffixed-top-ns base-names (source namespaces)))))
+            (brick-ns-deps brick-id type suffixed-top-ns interface-names base-names (source namespaces)))))
 
-(defn valid-interface? [{:keys [to-brick-id to-namespace]} interface-names interface-ns]
-  (and (contains? interface-names to-brick-id)
-       (common/interface-ns? to-namespace interface-ns)))
+(defn interface-dep? [{:keys [to-type to-namespace]} interface-ns source]
+  (and (= "interface" to-type)
+       (or (= :test source)
+           (common/interface-ns? to-namespace interface-ns))))
 
-(defn deps-for-source [suffixed-top-ns interface-names base-names {:keys [type] :as brick} interface-ns source]
-  (let [deps (brick-deps-for-source suffixed-top-ns brick base-names source)
-        dep-ids (set (map :to-brick-id deps))
-        interface-deps (if (= :test source)
-                         (set/intersection dep-ids interface-names)
-                         (set (map :to-brick-id
-                                   (filter #(valid-interface? % interface-names interface-ns)
-                                           deps))))
-        base-deps (set/intersection dep-ids base-names)
-        valid-deps (if (= "component" type)
-                     interface-deps
-                     (set/union interface-deps base-deps))
-        illegal-deps (filterv #(not (contains? valid-deps (:to-brick-id %)))
-                              deps)]
-    [(vec (sort interface-deps))
-     (vec (sort base-deps))
-     illegal-deps]))
+(defn illegal-dep? [{:keys [from-type to-type to-namespace]} interface-ns source]
+  (or (and (= "component" from-type)
+           (= "base" to-type)
+           (= :src source))
+      (and (= "interface" to-type)
+           (= :src source)
+           (not (common/interface-ns? to-namespace interface-ns)))))
+
+(defn base? [{:keys [to-type]}]
+  (= "base" to-type))
+
+(defn unique-ids [deps]
+  (vec (sort (set deps))))
+
+(defn deps-for-source [suffixed-top-ns interface-names base-names brick interface-ns source]
+  (let [deps (brick-deps-for-source suffixed-top-ns brick interface-names base-names source)
+        interface-deps (map :to-brick-id
+                            (filter #(interface-dep? % interface-ns source)
+                                    deps))
+        base-deps (set/intersection (map :to-brick-id
+                                         (filter base? deps)))
+        illegal-deps (filter #(illegal-dep? % interface-ns source) deps)]
+    [(unique-ids interface-deps)
+     (unique-ids base-deps)
+     (unique-ids illegal-deps)]))
 
 (defn brick-deps
   "Returns the interface and base dependencies for a brick (component or base)."

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,7 +25,7 @@
 (def minor 2)
 (def patch 20)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 22) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 23) ;; Increase by one for every snapshot release, or set to 0 if a release.
                   ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 

--- a/components/workspace/src/polylith/clj/core/workspace/enrich/core.clj
+++ b/components/workspace/src/polylith/clj/core/workspace/enrich/core.clj
@@ -54,10 +54,10 @@
           brick->loc (brick->loc enriched-bricks)
           brick->lib-imports (brick->lib-imports enriched-bricks)
           alias-id (atom 0)
-          enriched-projects (vec (sort-by project-sorter
-                                          (mapv #(project/enrich-project % ws-dir alias-id enriched-components enriched-bases profiles suffixed-top-ns brick->loc brick->lib-imports paths user-input settings name-type->keep-lib-versions outdated-libs library->latest-version)
-                                                projects)))
           enriched-settings (test-configs/with-configs settings test configs user-input)
+          enriched-projects (vec (sort-by project-sorter
+                                          (mapv #(project/enrich-project % ws-dir alias-id enriched-components enriched-bases profiles suffixed-top-ns brick->loc brick->lib-imports paths user-input enriched-settings name-type->keep-lib-versions outdated-libs library->latest-version)
+                                                projects)))
           messages (validator/validate-ws settings paths interface-names interfaces profiles enriched-components enriched-bases enriched-projects config-errors interface-ns user-input color-mode)]
       (cond-> workspace
               true (assoc :interfaces interfaces

--- a/examples/missing-component/bases/mybase/src/missing/mybase/core.clj
+++ b/examples/missing-component/bases/mybase/src/missing/mybase/core.clj
@@ -1,2 +1,3 @@
 (ns missing.mybase.core
-  (:require [missing.mycomp.interface :as mycomp]))
+  (:require [missing.mycomp.interface :as mycomp]
+            [missing.ignoreme.core :as ignoreme]))

--- a/projects/poly/test/project/poly/poly_workspace_test.clj
+++ b/projects/poly/test/project/poly/poly_workspace_test.clj
@@ -1451,10 +1451,12 @@
 (deftest test-runner-inherit-test-runner-from-global
   (is (= ["{:create-test-runner"
           " [org.corfield.external-test-runner.interface/create],"
-          " :setup-fn se.external.test-setup.interface/setup}"]
+          " :setup-fn se.external.test-setup.interface/setup,"
+          " :org.corfield/external-test-runner {:focus {:exclude [:dummy]}}}"]
          (run-cmd "examples/test-runners"
                   "ws"
-                  "get:projects:external-inherit-from-global:test"))))
+                  "get:projects:external-inherit-from-global:test"
+                  "with:exclude-dummy"))))
 
 (deftest test-runner-override-global-test-runner
   (is (= ["{:create-test-runner [polylith-kaocha.test-runner/create],"

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 image::doc/images/logo.png[width=400]
-:snapshot-version: 22
+:snapshot-version: 23
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc
 
 https://cljdoc.org/d/polylith/clj-poly/0.2.19/doc/readme[image:https://badgen.net/badge/doc/0.2.19/blue[]]


### PR DESCRIPTION
When validating dependencies (error 101) only check interfaces and bases that match the interfaces and bases in the workspace. This means we should allow the code to depend on namespaces with other names (which could potentially be imported libraries with the same top namespace).

Also, make sure we include :test config per project, when using the with:test-snippet syntax. 