### PR TITLE
Extend bricks to test calculation

### DIFF
--- a/components/test/src/polylith/clj/core/test/bricks_to_test.clj
+++ b/components/test/src/polylith/clj/core/test/bricks_to_test.clj
@@ -49,8 +49,11 @@
 (defn with-bricks-to-test [project changed-projects changed-components changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
   (assoc project
          :bricks-to-test
-         (-> (concat (bricks-to-test project :src changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-                     (bricks-to-test project :src changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-                     (bricks-to-test project :test changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-                     (bricks-to-test project :test changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests))
-             set sort vec)))
+         (vec
+          (into
+           (sorted-set)
+           cat
+           [(bricks-to-test project :src changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
+            (bricks-to-test project :src changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
+            (bricks-to-test project :test changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
+            (bricks-to-test project :test changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)]))))

--- a/components/test/src/polylith/clj/core/test/bricks_to_test.clj
+++ b/components/test/src/polylith/clj/core/test/bricks_to_test.clj
@@ -30,7 +30,7 @@
 (defn bricks-to-test [{:keys [test indirect-changes]}
                       source
                       changed-bricks
-                      user-selected-bricks
+                      selected-bricks
                       include-project
                       project-has-changed
                       is-run-all-brick-tests
@@ -38,22 +38,22 @@
   (let [;; If the :test > :include or :test > :exclude keys are given for a project in workspace.edn,
         ;; then only include the specified bricks, otherwise, run tests for all bricks.
         included-bricks (common/brick-names-to-test test eligible-bricks)
-        user-selected-bricks (if user-selected-bricks (set user-selected-bricks) eligible-bricks)
-        selected-bricks (if include-project
+        selected-bricks (if selected-bricks (set selected-bricks) eligible-bricks)
+        changed-bricks (if include-project
                           (if (or is-run-all-brick-tests project-has-changed)
                             ;; if we pass in :all or :all-bricks or if the project has changed then always run all brick tests.
                             included-bricks
                             (set/intersection included-bricks
-                                              user-selected-bricks
+                                              selected-bricks
                                               (into #{} cat
                                                     [changed-bricks (source indirect-changes)])))
                           #{})]
     ;; And finally, if brick:BRICK is given, also filter on that, which means that if we
     ;; pass in both brick:BRICK and :all, we will run the tests for all these bricks,
     ;; whether they have changed or not (directly or indirectly).
-    (set/intersection selected-bricks user-selected-bricks)))
+    (set/intersection changed-bricks selected-bricks)))
 
-(defn with-bricks-to-test [project changed-projects changed-components changed-bases user-selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
+(defn with-bricks-to-test [project changed-projects changed-components changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
   (let [changed-bricks (into [] cat [changed-bases changed-components])
         include-project (include-project? project selected-projects is-dev-user-input)
         project-has-changed (project-changed? project changed-projects)]
@@ -66,21 +66,21 @@
              (mapcat #(bricks-to-test project
                                       %
                                       changed-bricks
-                                      user-selected-bricks
+                                      selected-bricks
                                       include-project
                                       project-has-changed
                                       is-run-all-brick-tests
                                       (bricks-for-source project %))))
            (vec))
       ;; might include bricks that don't have test sources
-      :bricks-to-test-2
+      :bricks-to-test-all-sources
       (->> [:src :test]
            (into
              (sorted-set)
              (mapcat #(bricks-to-test project
                                       %
                                       changed-bricks
-                                      user-selected-bricks
+                                      selected-bricks
                                       include-project
                                       project-has-changed
                                       is-run-all-brick-tests

--- a/components/test/src/polylith/clj/core/test/bricks_to_test.clj
+++ b/components/test/src/polylith/clj/core/test/bricks_to_test.clj
@@ -2,57 +2,69 @@
   (:require [clojure.set :as set]
             [polylith.clj.core.common.interface :as common]))
 
-(defn bricks-to-test [{:keys [is-dev alias name test base-names component-names indirect-changes]}
+(defn bricks-for-source [{:keys [base-names component-names]} source]
+  (if (= :test source)
+    ;; Make sure we only select bricks that are included in the project from the :test context.
+    (into #{} (mapcat :test) [base-names component-names])
+    ;; Also make sure the bricks are included in the :src context for the project
+    ;; when checking for changes for the :src context.
+    ;; If a brick is included in the project via its deps.edn as :local/root
+    ;; from :aliases > :test > :extra-deps, then it will only be included in :test
+    ;; in base-names/component-names (not :src).
+    (set/intersection (into #{} (mapcat :src) [base-names component-names])
+                      (into #{} (mapcat :test) [base-names component-names]))))
+
+(defn include-project? [{:keys [is-dev alias name]} selected-projects is-dev-user-input]
+  (or (or (contains? selected-projects name)
+          (contains? selected-projects alias))
+      (and (empty? selected-projects)
+           (or (not is-dev)
+               is-dev-user-input))))
+
+(defn project-changed? [{:keys [name]} changed-projects]
+  (contains? (set changed-projects) name))
+
+(defn bricks-to-test [{:keys [test indirect-changes]}
                       source
-                      changed-projects
                       changed-bricks
-                      selected-bricks
-                      selected-projects
-                      is-dev-user-input
-                      is-run-all-brick-tests]
-  (let [include-project? (or (or (contains? selected-projects name)
-                                 (contains? selected-projects alias))
-                             (and (empty? selected-projects)
-                                  (or (not is-dev)
-                                      is-dev-user-input)))
-        project-has-changed? (contains? (set changed-projects) name)
-        bricks-for-source (if (= :test source)
-                            ;; Make sure we only select bricks that are included in the project from the :test context.
-                            (into #{} (mapcat :test) [base-names component-names])
-                            ;; Also make sure the bricks are included in the :src context for the project
-                            ;; when checking for changes for the :src context.
-                            ;; If a brick is included in the project via its deps.edn as :local/root
-                            ;; from :aliases > :test > :extra-deps, then it will only be included in :test
-                            ;; in base-names/component-names (not :src).
-                            (set/intersection (into #{} (mapcat :src) [base-names component-names])
-                                              (into #{} (mapcat :test) [base-names component-names])))
-        ;; If the :test > :include or :test > :exclude keys are given for a project in workspace.edn,
+                      user-selected-bricks
+                      include-project
+                      project-has-changed
+                      is-run-all-brick-tests
+                      eligible-bricks]
+  (let [;; If the :test > :include or :test > :exclude keys are given for a project in workspace.edn,
         ;; then only include the specified bricks, otherwise, run tests for all bricks.
-        included-bricks (common/brick-names-to-test test bricks-for-source)
-        selected-bricks (if selected-bricks
-                          (set selected-bricks)
-                          bricks-for-source)
-        changed-bricks (if include-project?
-                         (if (or is-run-all-brick-tests project-has-changed?)
-                           ;; if we pass in :all or :all-bricks or if the project has changed then always run all brick tests.
-                           included-bricks
-                           (set/intersection included-bricks
-                                             selected-bricks
-                                             (into #{} cat
-                                                   [changed-bricks (source indirect-changes)])))
-                         #{})]
+        included-bricks (common/brick-names-to-test test eligible-bricks)
+        user-selected-bricks (if user-selected-bricks (set user-selected-bricks) eligible-bricks)
+        selected-bricks (if include-project
+                          (if (or is-run-all-brick-tests project-has-changed)
+                            ;; if we pass in :all or :all-bricks or if the project has changed then always run all brick tests.
+                            included-bricks
+                            (set/intersection included-bricks
+                                              user-selected-bricks
+                                              (into #{} cat
+                                                    [changed-bricks (source indirect-changes)])))
+                          #{})]
     ;; And finally, if brick:BRICK is given, also filter on that, which means that if we
     ;; pass in both brick:BRICK and :all, we will run the tests for all these bricks,
     ;; whether they have changed or not (directly or indirectly).
-    (set/intersection changed-bricks selected-bricks)))
+    (set/intersection selected-bricks user-selected-bricks)))
 
-(defn with-bricks-to-test [project changed-projects changed-components changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
-  (let [changed-bricks (into [] cat [changed-bases changed-components])]
+(defn with-bricks-to-test [project changed-projects changed-components changed-bases user-selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
+  (let [changed-bricks (into [] cat [changed-bases changed-components])
+        include-project (include-project? project selected-projects is-dev-user-input)
+        project-has-changed (project-changed? project changed-projects)]
     (assoc project
       :bricks-to-test
-      (vec
-        (into
-          (sorted-set)
-          cat
-          [(bricks-to-test project :src changed-projects changed-bricks selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-           (bricks-to-test project :test changed-projects changed-bricks selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)])))))
+      (->> [:src :test]
+           (into
+             (sorted-set)
+             (mapcat #(bricks-to-test project
+                                      %
+                                      changed-bricks
+                                      user-selected-bricks
+                                      include-project
+                                      project-has-changed
+                                      is-run-all-brick-tests
+                                      (bricks-for-source project %))))
+           (vec)))))

--- a/components/test/src/polylith/clj/core/test/bricks_to_test.clj
+++ b/components/test/src/polylith/clj/core/test/bricks_to_test.clj
@@ -47,13 +47,12 @@
     (set/intersection changed-bricks selected-bricks)))
 
 (defn with-bricks-to-test [project changed-projects changed-components changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests]
-  (assoc project
-         :bricks-to-test
-         (vec
-          (into
-           (sorted-set)
-           cat
-           [(bricks-to-test project :src changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-            (bricks-to-test project :src changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-            (bricks-to-test project :test changed-projects changed-bases selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
-            (bricks-to-test project :test changed-projects changed-components selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)]))))
+  (let [changed-bricks (into [] cat [changed-bases changed-components])]
+    (assoc project
+      :bricks-to-test
+      (vec
+        (into
+          (sorted-set)
+          cat
+          [(bricks-to-test project :src changed-projects changed-bricks selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)
+           (bricks-to-test project :test changed-projects changed-bricks selected-bricks selected-projects is-dev-user-input is-run-all-brick-tests)])))))

--- a/components/test/test/polylith/clj/core/test/bricks_to_test_test.clj
+++ b/components/test/test/polylith/clj/core/test/bricks_to_test_test.clj
@@ -23,10 +23,12 @@
                                          is-dev-user-input
                                          is-run-all-brick-tests))
       (fn
-        ([] {:bricks-to-test {}})
+        ([] {:bricks-to-test {} :bricks-to-test-2 {}})
         ([acc] acc)
-        ([acc {:keys [name bricks-to-test]}]
-         (update acc :bricks-to-test assoc name bricks-to-test)))
+        ([acc {:keys [name bricks-to-test bricks-to-test-2]}]
+         (-> acc
+             (update :bricks-to-test assoc name bricks-to-test)
+             (update :bricks-to-test-2 assoc name bricks-to-test-2))))
       projects)))
 
 ;; The development project is only included in the tests if we pass in :dev,
@@ -36,7 +38,11 @@
   (is (= {:bricks-to-test
           {"core" ["article" "rest-api"]
            "development" []
-           "extension" ["article"]}}
+           "extension" ["article"]}
+          :bricks-to-test-2
+          {"core" ["article" "rest-api"]
+           "development" []
+           "extension" ["article" "cli"]}}
          (test {:changed-projects []
                 :changed-components ["article"]
                 :changed-bases ["rest-api" "cli"]
@@ -47,6 +53,10 @@
 
 (deftest with-bricks-to-test--with-one-changed-component-that-is-excluded---returns-bricks-to-test-for-changed-projects
   (is (= {:bricks-to-test
+          {"core" []
+           "development" []
+           "extension" []}
+          :bricks-to-test-2
           {"core" []
            "development" []
            "extension" []}}
@@ -68,7 +78,18 @@
                    "user"]
            "development" []
            "extension" ["article"
-                        "comment"]}}
+                        "comment"]}
+          :bricks-to-test-2
+          {"core" ["article"
+                   "comment"
+                   "rest-api"
+                   "tag"
+                   "user"]
+           "development" []
+           "extension" ["article"
+                        "cli"
+                        "comment"
+                        "section"]}}
          (test {:changed-projects []
                 :changed-components ["article"]
                 :changed-bases []
@@ -91,7 +112,23 @@
                           "tag"
                           "user"]
            "extension" ["article"
-                        "comment"]}}
+                        "comment"]}
+          :bricks-to-test-2
+          {"core" ["article"
+                   "comment"
+                   "rest-api"
+                   "tag"
+                   "user"]
+           "development" ["article"
+                          "comment"
+                          "profile"
+                          "rest-api"
+                          "tag"
+                          "user"]
+           "extension" ["article"
+                        "cli"
+                        "comment"
+                        "section"]}}
          (test {:changed-projects []
                 :changed-components ["article"]
                 :changed-bases []
@@ -102,6 +139,15 @@
 
 (deftest with-bricks-to-test--with-run-all-brick-tests-and-development-selected--returns-all-bricks-for-development
   (is (= {:bricks-to-test
+          {"core" []
+           "development" ["article"
+                          "comment"
+                          "profile"
+                          "rest-api"
+                          "tag"
+                          "user"]
+           "extension" []}
+          :bricks-to-test-2
           {"core" []
            "development" ["article"
                           "comment"
@@ -123,11 +169,16 @@
           {"core" ["tag"
                    "user"]
            "development" []
+           "extension" []}
+          :bricks-to-test-2
+          {"core" ["tag"
+                   "user"]
+           "development" []
            "extension" []}}
          (test {:changed-projects []
                 :test {:include ["tag" "user"]}
-                :changed-components ["article" "comment" "rest-api" "tag" "user"]
-                :changed-bases []
+                :changed-components ["article" "comment" "tag" "user"]
+                :changed-bases ["rest-api"]
                 :selected-bricks nil
                 :selected-projects #{}
                 :is-dev-user-input false
@@ -141,10 +192,19 @@
                    "tag"
                    "user"]
            "development" []
-           "extension" ["article"]}}
+           "extension" ["article"]}
+          :bricks-to-test-2
+          {"core" ["article"
+                   "comment"
+                   "rest-api"
+                   "tag"
+                   "user"]
+           "development" []
+           "extension" ["article"
+                        "cli"]}}
          (test {:changed-projects ["core"]
                 :changed-components ["article"]
-                :changed-bases []
+                :changed-bases ["cli"]
                 :selected-bricks nil
                 :selected-projects #{}
                 :is-dev-user-input false
@@ -152,6 +212,10 @@
 
 (deftest with-bricks-to-test--with-two-changed-components-and-one-selected-brick--returns-selected-bricks-that-are-also-changed
   (is (= {:bricks-to-test
+          {"core" ["user"]
+           "development" []
+           "extension" []}
+          :bricks-to-test-2
           {"core" ["user"]
            "development" []
            "extension" []}}
@@ -167,6 +231,10 @@
   (is (= {:bricks-to-test
           {"core" []
            "development" []
+           "extension" []}
+          :bricks-to-test-2
+          {"core" []
+           "development" []
            "extension" []}}
          (test {:changed-projects []
                 :changed-components []
@@ -180,11 +248,31 @@
   (is (= {:bricks-to-test
           {"core" ["tag"]
            "development" []
+           "extension" []}
+          :bricks-to-test-2
+          {"core" ["tag"]
+           "development" []
            "extension" []}}
          (test {:changed-projects []
                 :changed-components []
                 :changed-bases []
                 :selected-bricks ["tag"]
+                :selected-projects #{}
+                :is-dev-user-input false
+                :is-run-all-brick-tests true})))
+
+  (is (= {:bricks-to-test
+          {"core" []
+           "development" []
+           "extension" []}
+          :bricks-to-test-2
+          {"core" []
+           "development" []
+           "extension" ["section"]}}
+         (test {:changed-projects []
+                :changed-components []
+                :changed-bases []
+                :selected-bricks ["section"]
                 :selected-projects #{}
                 :is-dev-user-input false
                 :is-run-all-brick-tests true}))))

--- a/components/test/test/polylith/clj/core/test/bricks_to_test_test.clj
+++ b/components/test/test/polylith/clj/core/test/bricks_to_test_test.clj
@@ -23,12 +23,12 @@
                                          is-dev-user-input
                                          is-run-all-brick-tests))
       (fn
-        ([] {:bricks-to-test {} :bricks-to-test-2 {}})
+        ([] {:bricks-to-test {} :bricks-to-test-all-sources {}})
         ([acc] acc)
-        ([acc {:keys [name bricks-to-test bricks-to-test-2]}]
+        ([acc {:keys [name bricks-to-test bricks-to-test-all-sources]}]
          (-> acc
              (update :bricks-to-test assoc name bricks-to-test)
-             (update :bricks-to-test-2 assoc name bricks-to-test-2))))
+             (update :bricks-to-test-all-sources assoc name bricks-to-test-all-sources))))
       projects)))
 
 ;; The development project is only included in the tests if we pass in :dev,
@@ -39,7 +39,7 @@
           {"core" ["article" "rest-api"]
            "development" []
            "extension" ["article"]}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["article" "rest-api"]
            "development" []
            "extension" ["article" "cli"]}}
@@ -56,7 +56,7 @@
           {"core" []
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" []
            "development" []
            "extension" []}}
@@ -79,7 +79,7 @@
            "development" []
            "extension" ["article"
                         "comment"]}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["article"
                    "comment"
                    "rest-api"
@@ -113,7 +113,7 @@
                           "user"]
            "extension" ["article"
                         "comment"]}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["article"
                    "comment"
                    "rest-api"
@@ -147,7 +147,7 @@
                           "tag"
                           "user"]
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" []
            "development" ["article"
                           "comment"
@@ -170,7 +170,7 @@
                    "user"]
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["tag"
                    "user"]
            "development" []
@@ -193,7 +193,7 @@
                    "user"]
            "development" []
            "extension" ["article"]}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["article"
                    "comment"
                    "rest-api"
@@ -215,7 +215,7 @@
           {"core" ["user"]
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["user"]
            "development" []
            "extension" []}}
@@ -232,7 +232,7 @@
           {"core" []
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" []
            "development" []
            "extension" []}}
@@ -249,7 +249,7 @@
           {"core" ["tag"]
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" ["tag"]
            "development" []
            "extension" []}}
@@ -265,7 +265,7 @@
           {"core" []
            "development" []
            "extension" []}
-          :bricks-to-test-2
+          :bricks-to-test-all-sources
           {"core" []
            "development" []
            "extension" ["section"]}}

--- a/components/test/test/polylith/clj/core/test/test_data.clj
+++ b/components/test/test/polylith/clj/core/test/test_data.clj
@@ -18,6 +18,15 @@
            :base-names {:src ["rest-api"]
                         :test ["rest-api"]}})
 
+(def ext {:is-dev false
+          :alias "ext"
+          :name "extension"
+          :component-names {:src ["article" "comment" "section"]
+                            :test ["article" "comment"]}
+          :base-names {:src ["cli"]
+                       :test []}})
+
 (defn projects [test]
   [dev
-   (assoc core :test test)])
+   (assoc core :test test)
+   (assoc ext :test test)])

--- a/deps.edn
+++ b/deps.edn
@@ -64,6 +64,7 @@
                                  "components/lib/test"
                                  "components/path-finder/test"
                                  "components/shell/test"
+                                 "components/test/test"
                                  "components/test-runner-contract/test"
                                  "components/test-runner-orchestrator/test"
                                  "components/user-input/test"

--- a/doc/workspace-structure.adoc
+++ b/doc/workspace-structure.adoc
@@ -565,6 +565,7 @@ poly ws get:projects:user-service
 {:alias "user-s",
  :base-names {:src ["user-api"], :test ["user-api"]},
  :bricks-to-test ["user" "user-api"],
+ :bricks-to-test-all-sources ["user" "user-api"],
  :component-names {:src ["user"], :test ["user"]},
  :deps {"user" {:src {}, :test {}},
         "user-api" {:src {:direct ["user"]}, :test {:direct ["user"]}}},
@@ -617,7 +618,8 @@ poly ws get:projects:user-service
 ** `:src` The bases that are included in the project for the `src` context, either as paths or included as `:local/root`.
 ** `:test` The bases that are included in the project for the `test` context, either as paths or included as `:local/root`.
 
-* `:bricks-to-test` A vector with the bricks to test from this project if executing the xref:commands.adoc#test[test] command.
+* `:bricks-to-test` A vector with the bricks to test from this project if executing the xref:commands.adoc#test[test] command. Only contains bricks that have `:test` paths.
+* `:bricks-to-test-all-sources` Like `:bricks-to-test`, but also contains bricks that do not have `:test` paths.
 
 * `:component-names`
 ** `:src` The components that are included in the project for the `src` context, either as paths or included as `:local/root`.


### PR DESCRIPTION
Adds a new key to `project` (`bricks-to-test-all-sources`) which differs from `bricks-to-test` in that it might contain bricks that don't have any dedicated test sources.

This is to let test runners discover potential tests in src-only bricks as well. (Like Kaocha's [automatic spec test generation](https://github.com/lambdaisland/kaocha/blob/main/doc/spec_test_check.md))

TODO:

- [x] find a better name for the new key
- [x] update docs

Also see #448 