### PR TITLE
add polylith-kaocha to cljs-support to check cljs compatibility

### DIFF
--- a/examples/mix-example/deps.edn
+++ b/examples/mix-example/deps.edn
@@ -24,10 +24,18 @@
                                  "components/comp-cljs-with-macros/test"
                                  
                                  "bases/clj-base/test"
-                                 "bases/cljs-base/test"]}
+                                 "bases/cljs-base/test"]
+                   :extra-deps {polylith-kaocha/kaocha-wrapper
+                                {:git/url "https://github.com/imrekoszo/polylith-kaocha"
+                                 :git/tag "v0.8.6"
+                                 :git/sha "7282409"
+                                 :deps/root "projects/kaocha-wrapper"}}}
 
             :poly {:main-opts ["-m" "polylith.clj.core.poly-cli.core"]
-                   :extra-deps {polylith/clj-poly
-                                {:git/url "https://github.com/polyfy/polylith.git"
-                                 :sha "38e14b1e58931d31b491eb4054450cd4975b529f"
-                                 :deps/root "projects/poly"}}}}}
+                   :extra-deps {polylith-kaocha/test-runner
+                                {:git/url "https://github.com/imrekoszo/polylith-kaocha"
+                                 :git/tag "v0.8.6"
+                                 :git/sha "7282409"
+                                 :deps/root "projects/test-runner"}
+                                polylith/clj-poly
+                                {:local/root "../../projects/poly"}}}}}

--- a/examples/mix-example/projects/clj-project/deps.edn
+++ b/examples/mix-example/projects/clj-project/deps.edn
@@ -8,5 +8,8 @@
         org.clojure/clojure {:mvn/version "1.12.0"}}
 
  :aliases {:test {:extra-paths []
-                  :extra-deps  {}}}}
-
+                  :extra-deps  {polylith-kaocha/kaocha-wrapper
+                                {:git/url "https://github.com/imrekoszo/polylith-kaocha"
+                                 :git/tag "v0.8.6"
+                                 :git/sha "7282409"
+                                 :deps/root "projects/kaocha-wrapper"}}}}}

--- a/examples/mix-example/projects/cljs-project/deps.edn
+++ b/examples/mix-example/projects/cljs-project/deps.edn
@@ -20,4 +20,8 @@
                                 "../../components/comp-cljs-with-macros/test"
 
                                 "../../bases/cljs-base/test"]
-                  :extra-deps  {}}}}
+                  :extra-deps  {polylith-kaocha/kaocha-wrapper
+                                {:git/url "https://github.com/imrekoszo/polylith-kaocha"
+                                 :git/tag "v0.8.6"
+                                 :git/sha "7282409"
+                                 :deps/root "projects/kaocha-wrapper"}}}}}

--- a/examples/mix-example/projects/cljs-project/resources/cljs_project/tests.edn
+++ b/examples/mix-example/projects/cljs-project/resources/cljs_project/tests.edn
@@ -1,0 +1,2 @@
+#kaocha/v1
+{:reporter kaocha.report/documentation}

--- a/examples/mix-example/workspace.edn
+++ b/examples/mix-example/workspace.edn
@@ -9,4 +9,6 @@
                 :release "v[0-9]*"}
  :projects {"development" {:alias "dev"}
             "clj-project" {:alias "clj"}
-            "cljs-project" {:alias "cljs"}}}
+            "cljs-project" {:alias "cljs"
+                            :test {:polylith-kaocha/config-resource "cljs_project/tests.edn"}}}
+ :test-configs {:kaocha-test-runner {:create-test-runner [polylith-kaocha.test-runner/create]}}}


### PR DESCRIPTION
@tengstrand asked me to look into making polylith-kaocha compatible with the cljs support effort.

This PR adds polylith-kaocha to the cljs examples. Running `clojure -Srepro -M:poly test :all :project with:kaocha-test-runner` will list the tests ran in the context of `cljs-project`, showing that only the CLJ/CLJC tests are executed.

I didn't need to make any specific changes to polylith-kaocha for this to work, kaocha itself handles this out of the box.