### PR TITLE
Update tag-patterns regex

### DIFF
--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,7 +25,7 @@
 (def minor 2)
 (def patch 22)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 6) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 7) ;; Increase by one for every snapshot release, or set to 0 if a release.
                   ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 

--- a/examples/doc-example/workspace.edn
+++ b/examples/doc-example/workspace.edn
@@ -4,8 +4,8 @@
  :compact-views #{}
  :vcs {:name "git"
        :auto-add true}
- :tag-patterns {:stable "stable-*"
-                :release "v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "command-line" {:alias "cl"}
             "user-service" {:alias "user-s"}}}

--- a/examples/doc-example/ws.edn
+++ b/examples/doc-example/ws.edn
@@ -47,7 +47,7 @@
    :base-deps {:src [], :test []}}],
  :changes
  {:since "stable",
-  :since-sha "831c47c3992e7e1950e81f95877031186fff0b59",
+  :since-sha "7f0e6802202be3fc19112bfd2a2e8a5e83756717",
   :since-tag "stable-lisa",
   :changed-files
   ["bases/user-api/deps.edn"
@@ -63,7 +63,7 @@
    "projects/user-service/deps.edn"
    "workspace.edn"],
   :git-diff-command
-  "git diff 831c47c3992e7e1950e81f95877031186fff0b59 --name-only",
+  "git diff 7f0e6802202be3fc19112bfd2a2e8a5e83756717 --name-only",
   :changed-components ["user-remote"],
   :changed-bases ["user-api"],
   :changed-projects ["command-line" "user-service"],
@@ -332,7 +332,7 @@
  :projects
  [{:lines-of-code {:src 0, :test 13, :total {:src 42, :test 28}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/projects/command-line/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/command-line/deps.edn",
    :namespaces
    {:test
     [{:name "project.command-line.test-setup",
@@ -376,7 +376,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "cl",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/projects/command-line",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/command-line",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -404,7 +404,7 @@
     "user-remote" {:src {}, :test {}}}}
   {:lines-of-code {:src 0, :test 0, :total {:src 44, :test 28}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/projects/user-service/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/user-service/deps.edn",
    :namespaces {},
    :base-names {:src ["user-api"], :test ["user-api"]},
    :lib-imports {:src ["slacker.server"], :test ["clojure.test"]},
@@ -434,7 +434,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "user-s",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/projects/user-service",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/user-service",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -456,7 +456,7 @@
     "user" {:src {}, :test {}}}}
   {:lines-of-code {:src 4, :test 0, :total {:src 58, :test 42}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/deps.edn",
    :namespaces
    {:src
     [{:name "dev.lisa",
@@ -498,7 +498,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "dev",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example/development",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/development",
    :unmerged
    {:paths
     {:src
@@ -547,11 +547,11 @@
    :is-git-repo true,
    :branch "master",
    :git-root
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example",
    :auto-add true,
    :stable-since
    {:tag "stable-lisa",
-    :sha "831c47c3992e7e1950e81f95877031186fff0b59"},
+    :sha "7f0e6802202be3fc19112bfd2a2e8a5e83756717"},
    :polylith
    {:repo "https://github.com/polyfy/polylith.git", :branch "master"}},
   :top-namespace "se.example",
@@ -607,13 +607,13 @@
    :minor 2,
    :patch 22,
    :revision "SNAPSHOT",
-   :date "2025-05-13",
-   :snapshot 5},
+   :date "2025-05-15",
+   :snapshot 7},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0}},
  :ws-dir
- "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-081210/ws/example",
+ "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example",
  :ws-reader
  {:name "polylith-clj",
   :project-url "https://github.com/polyfy/polylith",

--- a/examples/for-test/workspace.edn
+++ b/examples/for-test/workspace.edn
@@ -4,8 +4,8 @@
  :interface-ns "interface"
  :default-profile-name "default"
  :compact-views #{}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
 
             "failing-test" {:alias "failing"

--- a/examples/illegal-brick-deps/workspace.edn
+++ b/examples/illegal-brick-deps/workspace.edn
@@ -4,7 +4,7 @@
  :compact-views #{}
  :vcs {:name "git"
        :auto-add false}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "system" {:alias "sys"}}}

--- a/examples/illegal-configs/workspace.edn
+++ b/examples/illegal-configs/workspace.edn
@@ -4,8 +4,8 @@
  :interface-ns "interface"
  :default-profile-name "default"
  :compact-views #{}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "service" {:alias "service"
                        :necessary ["util"]}}}

--- a/examples/local-dep/workspace.edn
+++ b/examples/local-dep/workspace.edn
@@ -4,8 +4,8 @@
  :interface-ns "interface"
  :default-profile-name "default"
  :compact-views #{}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "invoicing" {:alias "inv"
                          :necessary ["datomic-ions" "without-src"]}}}

--- a/examples/missing-component/workspace.edn
+++ b/examples/missing-component/workspace.edn
@@ -4,7 +4,7 @@
  :compact-views #{}
  :vcs {:name "git"
        :auto-add false}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "service"     {:alias "s"}}}

--- a/examples/poly-rcf/workspace.edn
+++ b/examples/poly-rcf/workspace.edn
@@ -4,8 +4,8 @@
  :compact-views #{}
  :vcs {:name "git"
        :auto-add false}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
 
  ;; Add this line to use the external test runner.
  ;; :test {:create-test-runner [org.corfield.external-test-runner.interface/create]}

--- a/examples/profiles/workspace.edn
+++ b/examples/profiles/workspace.edn
@@ -4,7 +4,7 @@
  :interface-ns "interface"
  :default-profile-name "default"
  :compact-views #{}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
             "service" {:alias "s"}}}

--- a/examples/test-runners/workspace.edn
+++ b/examples/test-runners/workspace.edn
@@ -5,8 +5,8 @@
  :test {:create-test-runner org.corfield.external-test-runner.interface/create}
  :vcs {:name "git"
        :auto-add false}
- :tag-patterns {:stable "^stable-*"
-                :release "^v[0-9]*"}
+ :tag-patterns {:stable "^stable-.*"
+                :release "^v[0-9].*"}
  :projects {"development" {:alias "dev"}
 
             "external-inherit-from-global" {:alias "inherit"

--- a/projects/poly/test/project/poly/poly_workspace_test.clj
+++ b/projects/poly/test/project/poly/poly_workspace_test.clj
@@ -1491,8 +1491,8 @@
             :default-profile-name "default"
             :empty-character      "."
             :interface-ns         "interface"
-            :tag-patterns         {:release "^v[0-9]*"
-                                   :stable  "^stable-*"}
+            :tag-patterns         {:release "^v[0-9].*"
+                                   :stable  "^stable-.*"}
             :thousand-separator   ","
             :top-namespace        "se.example"
             :vcs                  {:auto-add    true

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 image::doc/images/logo.png[width=400]
-:snapshot-number: 6
+:snapshot-number: 7
 :snapshot-version: 0.2.22
 :stable-version: 0.2.21
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc

--- a/scripts/output/local-dep-old-format/ws.edn
+++ b/scripts/output/local-dep-old-format/ws.edn
@@ -882,7 +882,7 @@
    :patch 22,
    :revision "SNAPSHOT",
    :date "2025-05-15",
-   :snapshot 6},
+   :snapshot 7},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0},

--- a/scripts/output/local-dep/ws.edn
+++ b/scripts/output/local-dep/ws.edn
@@ -367,7 +367,7 @@
    :interface-ns "interface",
    :default-profile-name "default",
    :compact-views #{},
-   :tag-patterns {:stable "^stable-*", :release "^v[0-9]*"},
+   :tag-patterns {:stable "^stable-.*", :release "^v[0-9].*"},
    :projects
    {"development" {:alias "dev"},
     "invoicing"
@@ -745,7 +745,7 @@
    :stable-since {:tag "stable-master", :sha "SHA"},
    :polylith
    {:repo "https://github.com/polyfy/polylith.git", :branch "master"}},
-  :tag-patterns {:stable "^stable-*", :release "^v[0-9]*"},
+  :tag-patterns {:stable "^stable-.*", :release "^v[0-9].*"},
   :m2-dir "USER-HOME/.m2",
   :color-mode "none",
   :empty-character "."},
@@ -800,7 +800,7 @@
    :patch 22,
    :revision "SNAPSHOT",
    :date "2025-05-15",
-   :snapshot 5},
+   :snapshot 7},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0}},


### PR DESCRIPTION
Set to `^stable-.*` and `^v[0-9].*` as default in workspace.edn for example projects.
Issue #534 (misleading branch name)