### PR TITLE
Better error messages for corrupt namespaces

### DIFF
--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -135,22 +135,38 @@
 
 (defn read-file [path]
   (try
-    (edamame/parse-string-all (slurp path)
-                              {:fn true
-                               :var true
-                               :quote true
-                               :regex true
-                               :deref true
-                               :read-eval true
-                               :features #{:clj}
-                               :readers source-reader
-                               :read-cond :allow
-                               :auto-resolve name
-                               :auto-resolve-ns true
-                               :syntax-quote {:resolve-symbol resolve-symbol}})
+    (let [content (slurp path)]
+      (if (str/blank? content)
+        ;; Return a special marker for empty files
+        :polylith.clj.core.file.interface/empty-file
+        (edamame/parse-string-all content
+                                  {:fn true
+                                   :var true
+                                   :quote true
+                                   :regex true
+                                   :deref true
+                                   :read-eval true
+                                   :features #{:clj}
+                                   :readers source-reader
+                                   :read-cond :allow
+                                   :auto-resolve name
+                                   :auto-resolve-ns true
+                                   :syntax-quote {:resolve-symbol resolve-symbol}})))
     (catch ExceptionInfo e
-     (let [{:keys [row col]} (ex-data e)]
-       (println (str "  Couldn't read file '" path "', row: " row ", column: " col ". Message: " (.getMessage e)))))))
+      (let [{:keys [row col]} (ex-data e)]
+        (println (str "  Couldn't read file '" path "', row: " row ", column: " col ". Message: " (.getMessage e)))
+       ;; Return a map with error information including the file path
+        {:error true
+         :file-path path
+         :message (.getMessage e)
+         :row row
+         :col col}))
+    (catch Exception e
+      (println (str "  Error reading file '" path "': " (.getMessage e)))
+      ;; Return a map with error information for non-ExceptionInfo exceptions
+      {:error true
+       :file-path path
+       :message (.getMessage e)})))
 
 (defn copy-resource-file! [source target-path]
   (delete-file target-path)

--- a/components/validator/src/polylith/clj/core/validator/m111_unreadable_namespace.clj
+++ b/components/validator/src/polylith/clj/core/validator/m111_unreadable_namespace.clj
@@ -2,10 +2,18 @@
   (:require [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))
 
-(defn unreadable-ns [{:keys [file-path is-invalid]} type name color-mode]
+(defn unreadable-ns [{:keys [file-path is-invalid empty-file error-message]} type name color-mode]
   (when is-invalid
-    (let [message (str "Unreadable namespace in " (color/brick type name color-mode) ": " file-path ". "
-                       "To solve this problem, execute 'poly help check' and follow the instructions for error 111.")]
+    (let [message-prefix (str "Unreadable namespace in " (color/brick type name color-mode) ": " file-path)
+          message (cond
+                    empty-file
+                    (str message-prefix ". File is empty. Please add a namespace declaration.")
+
+                    error-message
+                    (str message-prefix ". " error-message)
+
+                    :else
+                    (str message-prefix ". To solve this problem, execute 'poly help check' and follow the instructions for error 111."))]
       [(util/ordered-map :type "error"
                          :code 111
                          :message (color/clean-colors message)

--- a/components/workspace/test/polylith/clj/core/workspace/fromdisk/empty_file_test.clj
+++ b/components/workspace/test/polylith/clj/core/workspace/fromdisk/empty_file_test.clj
@@ -1,0 +1,69 @@
+(ns polylith.clj.core.workspace.fromdisk.empty-file-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [me.raynes.fs :as fs]
+            [polylith.clj.core.file.interface :as file]
+            [polylith.clj.core.workspace.fromdisk.namespaces-from-disk :as from-disk]))
+
+(deftest empty-file--namespace-extraction--should-handle-error-with-path-info
+  (let [temp-dir (str (fs/temp-dir "poly-test"))
+        empty-file-path (str temp-dir "/empty_component.clj")]
+    (try
+      ;; Create an empty file
+      (spit empty-file-path "")
+      
+      ;; Attempt to process the file - this should not throw an unhandled exception
+      ;; but instead return a properly formatted error
+      (let [namespace (from-disk/->namespace
+                        temp-dir 
+                        temp-dir 
+                        "test.core." 
+                        "interface" 
+                        empty-file-path)]
+        
+        ;; The namespace extraction should mark the file as invalid
+        ;; but not fail entirely with an unhandled exception
+        (is (map? namespace) "Should return a namespace map, not throw an exception")
+        (is (:is-invalid namespace) "Empty file should be marked as invalid")
+        (is (= "" (:namespace namespace)) "Empty file should have empty namespace string")
+        (is (str/ends-with? empty-file-path (:file-path namespace)) "File path should be preserved")
+        
+        ;; Test the underlying file/read-file function directly
+        (let [content (file/read-file empty-file-path)]
+          (is (= content :polylith.clj.core.file.interface/empty-file) "Empty file should be handled gracefully")))
+      
+      (finally
+        ;; Clean up
+        (fs/delete-dir temp-dir)))))
+
+(deftest real-file-loading--empty-file--should-return-error-with-file-path
+  (let [temp-dir (str (fs/temp-dir "poly-test"))
+        empty-file-path (str temp-dir "/src/test/core.clj")]
+    (try
+      ;; Create directory structure
+      (fs/mkdirs (str temp-dir "/src/test"))
+      ;; Create an empty file
+      (spit empty-file-path "")
+      
+      ;; Try to load namespaces from this directory structure
+      (let [namespaces (from-disk/namespaces-from-disk
+                         temp-dir
+                         [(str temp-dir "/src")]
+                         []
+                         "test."
+                         "interface")]
+        
+        ;; The namespace extraction should succeed but mark the file as invalid
+        (is (map? namespaces) "Should return a namespaces map")
+        (is (vector? (:src namespaces)) "Should have src vector")
+        (is (= 1 (count (:src namespaces))) "Should have one namespace")
+        
+        (let [ns-info (first (:src namespaces))]
+          (is (:is-invalid ns-info) "Empty file namespace should be marked as invalid")
+          (is (contains? ns-info :file-path) "Should contain file path")
+          (is (not (nil? (:file-path ns-info))) "File path should not be nil")))
+      
+      (finally
+        ;; Clean up
+        (fs/delete-dir temp-dir)))))

--- a/projects/poly/test/project/poly/poly_workspace_test.clj
+++ b/projects/poly/test/project/poly/poly_workspace_test.clj
@@ -1196,9 +1196,12 @@
                  "portal.api"
                  "puget.printer"
                  "selmer.parser"]
-          :test ["clojure.lang"
+          :test ["clojure.java.io"
+                 "clojure.lang"
+                 "clojure.string"
                  "clojure.test"
-                 "malli.core"]}
+                 "malli.core"
+                 "me.raynes.fs"]}
          (ws-explorer/extract (workspace) ["projects" "poly" "lib-imports"]))))
 
 (deftest polylith-shell-component-lib-deps


### PR DESCRIPTION
Fixes #523 

Most of the code was generated by Claude Sonnet 3.7 and [clojure-mcp](https://github.com/bhauman/clojure-mcp)*

I've reviewed the code, improved it slightly, removed unnecessary whitespace changes, and manually tested it on the https://github.com/jeroenvandijk/clojure-polylith-realworld-example-app/ project, see screenshots below.

### Corrupt file
<img width="1003" alt="Screenshot 2025-05-28 at 17 38 52" src="https://github.com/user-attachments/assets/2413872f-ca6e-4bbf-900d-df4cfa3d556e" />

###  Empty file
<img width="1005" alt="Screenshot 2025-05-28 at 17 39 29" src="https://github.com/user-attachments/assets/80863ee4-79b4-42bf-ad6a-90b267d22b25" />

I believe the code is somewhat in the style of the rest of the Polylith code. Please note that I have considered creating a PR before without the help of AI, but because of my relative unfamiliarity with the project I didn't find a fix that time. So Claude helped me find a solution here, but I don't know if this is the best way to go about it. Since most of the code was generated with AI, it is also ok if you decide to fully ignore this PR.

(*) [See Claude chat here](https://claude.ai/share/dbb64e75-7ee3-43c3-9652-b9a57bf81421). I used Claude Sonnet 3.7. With Sonnet 4.0 I received rate limit errors, even with a Pro account. The attached project_summary.md was generated in a different chat.