### PR TITLE
Better error messages for corrupt namespaces + better test errors

### DIFF
--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -155,7 +155,6 @@
     (catch ExceptionInfo e
       (let [{:keys [row col]} (ex-data e)]
         (println (str "  Couldn't read file '" path "', row: " row ", column: " col ". Message: " (.getMessage e)))
-       ;; Return a map with error information including the file path
         {:error true
          :file-path path
          :message (.getMessage e)
@@ -163,7 +162,6 @@
          :col col}))
     (catch Exception e
       (println (str "  Error reading file '" path "': " (.getMessage e)))
-      ;; Return a map with error information for non-ExceptionInfo exceptions
       {:error true
        :file-path path
        :message (.getMessage e)})))

--- a/components/file/src/polylith/clj/core/file/core.clj
+++ b/components/file/src/polylith/clj/core/file/core.clj
@@ -135,22 +135,38 @@
 
 (defn read-file [path]
   (try
-    (edamame/parse-string-all (slurp path)
-                              {:fn true
-                               :var true
-                               :quote true
-                               :regex true
-                               :deref true
-                               :read-eval true
-                               :features #{:clj}
-                               :readers source-reader
-                               :read-cond :allow
-                               :auto-resolve name
-                               :auto-resolve-ns true
-                               :syntax-quote {:resolve-symbol resolve-symbol}})
+    (let [content (slurp path)]
+      (if (str/blank? content)
+        ;; Return a special marker for empty files
+        :polylith.clj.core.file.interface/empty-file
+        (edamame/parse-string-all content
+                                  {:fn true
+                                   :var true
+                                   :quote true
+                                   :regex true
+                                   :deref true
+                                   :read-eval true
+                                   :features #{:clj}
+                                   :readers source-reader
+                                   :read-cond :allow
+                                   :auto-resolve name
+                                   :auto-resolve-ns true
+                                   :syntax-quote {:resolve-symbol resolve-symbol}})))
     (catch ExceptionInfo e
-     (let [{:keys [row col]} (ex-data e)]
-       (println (str "  Couldn't read file '" path "', row: " row ", column: " col ". Message: " (.getMessage e)))))))
+      (let [{:keys [row col]} (ex-data e)]
+        (println (str "  Couldn't read file '" path "', row: " row ", column: " col ". Message: " (.getMessage e)))
+       ;; Return a map with error information including the file path
+        {:error true
+         :file-path path
+         :message (.getMessage e)
+         :row row
+         :col col}))
+    (catch Exception e
+      (println (str "  Error reading file '" path "': " (.getMessage e)))
+      ;; Return a map with error information for non-ExceptionInfo exceptions
+      {:error true
+       :file-path path
+       :message (.getMessage e)})))
 
 (defn copy-resource-file! [source target-path]
   (delete-file target-path)

--- a/components/validator/src/polylith/clj/core/validator/m111_unreadable_namespace.clj
+++ b/components/validator/src/polylith/clj/core/validator/m111_unreadable_namespace.clj
@@ -2,10 +2,18 @@
   (:require [polylith.clj.core.util.interface :as util]
             [polylith.clj.core.util.interface.color :as color]))
 
-(defn unreadable-ns [{:keys [file-path is-invalid]} type name color-mode]
+(defn unreadable-ns [{:keys [file-path is-invalid empty-file error-message]} type name color-mode]
   (when is-invalid
-    (let [message (str "Unreadable namespace in " (color/brick type name color-mode) ": " file-path ". "
-                       "To solve this problem, execute 'poly help check' and follow the instructions for error 111.")]
+    (let [message-prefix (str "Unreadable namespace in " (color/brick type name color-mode) ": " file-path)
+          message (cond
+                    empty-file
+                    (str message-prefix ". File is empty. Please add a namespace declaration.")
+
+                    error-message
+                    (str message-prefix ". " error-message)
+
+                    :else
+                    (str message-prefix ". To solve this problem, execute 'poly help check' and follow the instructions for error 111."))]
       [(util/ordered-map :type "error"
                          :code 111
                          :message (color/clean-colors message)

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -37,7 +37,7 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2025-05-29")
+(def date "2025-06-02")
 
 ;; Execute 'poly doc page:versions' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,7 +25,7 @@
 (def minor 2)
 (def patch 22)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 10) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 11) ;; Increase by one for every snapshot release, or set to 0 if a release.
                   ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 
@@ -37,7 +37,7 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2025-05-27")
+(def date "2025-05-29")
 
 ;; Execute 'poly doc page:versions' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})

--- a/components/workspace/test/polylith/clj/core/workspace/fromdisk/empty_file_test.clj
+++ b/components/workspace/test/polylith/clj/core/workspace/fromdisk/empty_file_test.clj
@@ -1,0 +1,69 @@
+(ns polylith.clj.core.workspace.fromdisk.empty-file-test
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [me.raynes.fs :as fs]
+            [polylith.clj.core.file.interface :as file]
+            [polylith.clj.core.workspace.fromdisk.namespaces-from-disk :as from-disk]))
+
+(deftest empty-file--namespace-extraction--should-handle-error-with-path-info
+  (let [temp-dir (str (fs/temp-dir "poly-test"))
+        empty-file-path (str temp-dir "/empty_component.clj")]
+    (try
+      ;; Create an empty file
+      (spit empty-file-path "")
+      
+      ;; Attempt to process the file - this should not throw an unhandled exception
+      ;; but instead return a properly formatted error
+      (let [namespace (from-disk/->namespace
+                        temp-dir 
+                        temp-dir 
+                        "test.core." 
+                        "interface" 
+                        empty-file-path)]
+        
+        ;; The namespace extraction should mark the file as invalid
+        ;; but not fail entirely with an unhandled exception
+        (is (map? namespace) "Should return a namespace map, not throw an exception")
+        (is (:is-invalid namespace) "Empty file should be marked as invalid")
+        (is (= "" (:namespace namespace)) "Empty file should have empty namespace string")
+        (is (str/ends-with? empty-file-path (:file-path namespace)) "File path should be preserved")
+        
+        ;; Test the underlying file/read-file function directly
+        (let [content (file/read-file empty-file-path)]
+          (is (= content :polylith.clj.core.file.interface/empty-file) "Empty file should be handled gracefully")))
+      
+      (finally
+        ;; Clean up
+        (fs/delete-dir temp-dir)))))
+
+(deftest real-file-loading--empty-file--should-return-error-with-file-path
+  (let [temp-dir (str (fs/temp-dir "poly-test"))
+        empty-file-path (str temp-dir "/src/test/core.clj")]
+    (try
+      ;; Create directory structure
+      (fs/mkdirs (str temp-dir "/src/test"))
+      ;; Create an empty file
+      (spit empty-file-path "")
+      
+      ;; Try to load namespaces from this directory structure
+      (let [namespaces (from-disk/namespaces-from-disk
+                         temp-dir
+                         [(str temp-dir "/src")]
+                         []
+                         "test."
+                         "interface")]
+        
+        ;; The namespace extraction should succeed but mark the file as invalid
+        (is (map? namespaces) "Should return a namespaces map")
+        (is (vector? (:src namespaces)) "Should have src vector")
+        (is (= 1 (count (:src namespaces))) "Should have one namespace")
+        
+        (let [ns-info (first (:src namespaces))]
+          (is (:is-invalid ns-info) "Empty file namespace should be marked as invalid")
+          (is (contains? ns-info :file-path) "Should contain file path")
+          (is (not (nil? (:file-path ns-info))) "File path should not be nil")))
+      
+      (finally
+        ;; Clean up
+        (fs/delete-dir temp-dir)))))

--- a/doc/commands.adoc
+++ b/doc/commands.adoc
@@ -14,7 +14,7 @@ poly help
 
 [source,text]
 ----
-  poly 0.2.22 (2025-05-15) - https://github.com/polyfy/polylith
+  poly 0.2.22 (2025-06-02) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/examples/doc-example/ws.edn
+++ b/examples/doc-example/ws.edn
@@ -47,7 +47,7 @@
    :base-deps {:src [], :test []}}],
  :changes
  {:since "stable",
-  :since-sha "7f0e6802202be3fc19112bfd2a2e8a5e83756717",
+  :since-sha "e7814a32632b5f947b379cd8d70be2390466755b",
   :since-tag "stable-lisa",
   :changed-files
   ["bases/user-api/deps.edn"
@@ -63,7 +63,7 @@
    "projects/user-service/deps.edn"
    "workspace.edn"],
   :git-diff-command
-  "git diff 7f0e6802202be3fc19112bfd2a2e8a5e83756717 --name-only",
+  "git diff e7814a32632b5f947b379cd8d70be2390466755b --name-only",
   :changed-components ["user-remote"],
   :changed-bases ["user-api"],
   :changed-projects ["command-line" "user-service"],
@@ -240,6 +240,7 @@
      {:dir "examples/local-dep-old-format"}
      {:dir "examples/missing-component"}
      {:dir "examples/integrant-system"}
+     {:dir "examples/local-maven-repo"}
      {:dir "examples/mix-example"}
      {:dir "examples/profiles"}
      {:dir "examples/poly-rcf"}
@@ -332,7 +333,7 @@
  :projects
  [{:lines-of-code {:src 0, :test 13, :total {:src 42, :test 28}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/command-line/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/projects/command-line/deps.edn",
    :namespaces
    {:test
     [{:name "project.command-line.test-setup",
@@ -376,7 +377,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "cl",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/command-line",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/projects/command-line",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -404,7 +405,7 @@
     "user-remote" {:src {}, :test {}}}}
   {:lines-of-code {:src 0, :test 0, :total {:src 44, :test 28}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/user-service/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/projects/user-service/deps.edn",
    :namespaces {},
    :base-names {:src ["user-api"], :test ["user-api"]},
    :lib-imports {:src ["slacker.server"], :test ["clojure.test"]},
@@ -434,7 +435,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "user-s",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/projects/user-service",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/projects/user-service",
    :lib-deps
    {:src
     {"org.clojure/clojure"
@@ -456,7 +457,7 @@
     "user" {:src {}, :test {}}}}
   {:lines-of-code {:src 4, :test 0, :total {:src 58, :test 42}},
    :deps-filename
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/deps.edn",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/deps.edn",
    :namespaces
    {:src
     [{:name "dev.lisa",
@@ -498,7 +499,7 @@
     "clojars" {:url "https://repo.clojars.org/"}},
    :alias "dev",
    :project-dir
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example/development",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example/development",
    :unmerged
    {:paths
     {:src
@@ -547,11 +548,11 @@
    :is-git-repo true,
    :branch "master",
    :git-root
-   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example",
+   "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example",
    :auto-add true,
    :stable-since
    {:tag "stable-lisa",
-    :sha "7f0e6802202be3fc19112bfd2a2e8a5e83756717"},
+    :sha "e7814a32632b5f947b379cd8d70be2390466755b"},
    :polylith
    {:repo "https://github.com/polyfy/polylith.git", :branch "master"}},
   :top-namespace "se.example",
@@ -575,6 +576,7 @@
   :is-compact false,
   :is-dev false,
   :is-fake-poly false,
+  :is-fail-if-nothing-to-test false,
   :is-github false,
   :is-hide-lib-size false,
   :is-latest-sha false,
@@ -607,13 +609,13 @@
    :minor 2,
    :patch 22,
    :revision "SNAPSHOT",
-   :date "2025-05-15",
-   :snapshot 7},
+   :date "2025-06-02",
+   :snapshot 11},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0}},
  :ws-dir
- "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-05-15-091646/ws/example",
+ "/private/var/folders/_0/7sl6982d6l7bzdlypmk308kw0000gn/T/polylith-example-2025-06-02-095921/ws/example",
  :ws-reader
  {:name "polylith-clj",
   :project-url "https://github.com/polyfy/polylith",

--- a/next-release.md
+++ b/next-release.md
@@ -9,6 +9,7 @@
 | [532](https://github.com/polyfy/polylith/issues/532) | Use :mvn/local-repo if specified in a project when running tests
 | [533](https://github.com/polyfy/polylith/issues/533) | Maps with tag literals as keys in test namespaces breaks test runner
 | [534](https://github.com/polyfy/polylith/issues/534) | Use correct regex in :tag-patterns in workspace.edn
+| [523](https://github.com/polyfy/polylith/issues/523) | Reporting not helpful for obscure errors
 
 | PR                                                 | Author          | Description                                                  
 |:---------------------------------------------------|-----------------|------------------------------------------------------------|
@@ -18,6 +19,7 @@
 | [521](https://github.com/polyfy/polylith/pull/521) | Sean Corfield   | Update circleci to use Clojure 1.12                        |
 | [522](https://github.com/polyfy/polylith/pull/522) | Jeroen van Dijk | Update dep info of polylith-external-test-runner to v0.6.1 |
 | [535](https://github.com/polyfy/polylith/pull/535) | [brettatoms](https://github.com/brettatoms) | fix comparing maven version numbers |
+| [547](https://github.com/polyfy/polylith/pull/547) | Jeroen van Dijk | Better error messages for corrupt namespaces               |
 
 | Other changes                                                                                                                    |
 |----------------------------------------------------------------------------------------------------------------------------------|

--- a/next-release.md
+++ b/next-release.md
@@ -5,11 +5,11 @@
 |:-----------------------------------------------------|--------------|
 | [508](https://github.com/polyfy/polylith/issues/508) | Allow slash in profile names
 | [509](https://github.com/polyfy/polylith/issues/509) | Include warnings in the check function in the API 
+| [523](https://github.com/polyfy/polylith/issues/523) | Reporting not helpful for obscure errors
 | [530](https://github.com/polyfy/polylith/issues/530) | Cause poly test to fail when no tests are run (optionally using extra arg to the command)
 | [532](https://github.com/polyfy/polylith/issues/532) | Use :mvn/local-repo if specified in a project when running tests
 | [533](https://github.com/polyfy/polylith/issues/533) | Maps with tag literals as keys in test namespaces breaks test runner
 | [534](https://github.com/polyfy/polylith/issues/534) | Use correct regex in :tag-patterns in workspace.edn
-| [523](https://github.com/polyfy/polylith/issues/523) | Reporting not helpful for obscure errors
 
 | PR                                                 | Author          | Description                                                  
 |:---------------------------------------------------|-----------------|------------------------------------------------------------|

--- a/projects/poly/test/project/poly/poly_workspace_test.clj
+++ b/projects/poly/test/project/poly/poly_workspace_test.clj
@@ -1196,9 +1196,12 @@
                  "portal.api"
                  "puget.printer"
                  "selmer.parser"]
-          :test ["clojure.lang"
+          :test ["clojure.java.io"
+                 "clojure.lang"
+                 "clojure.string"
                  "clojure.test"
-                 "malli.core"]}
+                 "malli.core"
+                 "me.raynes.fs"]}
          (ws-explorer/extract (workspace) ["projects" "poly" "lib-imports"]))))
 
 (deftest polylith-shell-component-lib-deps

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 image::doc/images/logo.png[width=400]
-:snapshot-number: 10
+:snapshot-number: 11
 :snapshot-version: 0.2.22
 :stable-version: 0.2.21
 :cljdoc-doc-url: https://cljdoc.org/d/polylith/clj-poly/CURRENT/doc

--- a/scripts/output/help/help.txt
+++ b/scripts/output/help/help.txt
@@ -1,4 +1,4 @@
-  poly 0.2.22 (2025-05-15) - https://github.com/polyfy/polylith
+  poly 0.2.22 (2025-06-02) - https://github.com/polyfy/polylith
 
   poly CMD [ARGS] - where CMD [ARGS] are:
 

--- a/scripts/output/local-dep-old-format/ws.edn
+++ b/scripts/output/local-dep-old-format/ws.edn
@@ -340,6 +340,7 @@
      {:dir "examples/local-dep-old-format"}
      {:dir "examples/missing-component"}
      {:dir "examples/integrant-system"}
+     {:dir "examples/local-maven-repo"}
      {:dir "examples/mix-example"}
      {:dir "examples/profiles"}
      {:dir "examples/poly-rcf"}
@@ -843,6 +844,7 @@
   :is-commit false,
   :is-run-project-tests false,
   :is-compact false,
+  :is-fail-if-nothing-to-test false,
   :replace
   [{:from "WS-HOME", :to "WS-HOME"}
    {:from "USER-HOME", :to "USER-HOME"}
@@ -881,8 +883,8 @@
    :minor 2,
    :patch 22,
    :revision "SNAPSHOT",
-   :date "2025-05-15",
-   :snapshot 7},
+   :date "2025-06-02",
+   :snapshot 11},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0},

--- a/scripts/output/local-dep/ws.edn
+++ b/scripts/output/local-dep/ws.edn
@@ -351,6 +351,7 @@
      {:dir "examples/local-dep-old-format"}
      {:dir "examples/missing-component"}
      {:dir "examples/integrant-system"}
+     {:dir "examples/local-maven-repo"}
      {:dir "examples/mix-example"}
      {:dir "examples/profiles"}
      {:dir "examples/poly-rcf"}
@@ -761,6 +762,7 @@
   :is-commit false,
   :is-run-project-tests false,
   :is-compact false,
+  :is-fail-if-nothing-to-test false,
   :replace
   [{:from "WS-HOME", :to "WS-HOME"}
    {:from "USER-HOME", :to "USER-HOME"}
@@ -799,8 +801,8 @@
    :minor 2,
    :patch 22,
    :revision "SNAPSHOT",
-   :date "2025-05-15",
-   :snapshot 7},
+   :date "2025-06-02",
+   :snapshot 11},
   :api {:breaking 1, :non-breaking 0},
   :test-runner-api {:breaking 1, :non-breaking 0},
   :ws {:breaking 3, :non-breaking 0}},


### PR DESCRIPTION
Improved PR #547 (thanks @jeroenvandijk)

We also got rid of the do statement when running tests (now we execute the test runner in a separate statement).
When the tests are executed with `:verbose` we print out the namespace before each test instead of all test statements (thanks @seancorfield for suggesting that).

