### PR TITLE
0.3.0-SNAPSHOT 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/examples/"
+    schedule:
+      interval: "weekly"
+    # turn it off by setting 'open-pull-requests-limit' to 0 or just remove this block
+    open-pull-requests-limit: 0

--- a/components/shell/src/polylith/clj/core/shell/candidate/engine.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/engine.clj
@@ -169,4 +169,5 @@
   (def step4 (select-candidates step3 ["deployer" true]))
   (def step5 (select-candidates step4 [:next false]))
   (def step6 (select-candidates step5 ["project" true]))
-  (def step7 (select-candidates step6 ["" false])))
+  (def step7 (select-candidates step6 ["" false]))
+  #__)

--- a/components/shell/src/polylith/clj/core/shell/candidate/selector/outdated_libs.clj
+++ b/components/shell/src/polylith/clj/core/shell/candidate/selector/outdated_libs.clj
@@ -5,10 +5,20 @@
             [polylith.clj.core.lib.interface :as lib]
             [polylith.clj.core.shell.candidate.shared :as shared]))
 
-(defn select [{:keys [group]} groups {:keys [configs]}]
+(def outdated-libs (atom nil))
+
+(defn reset-outdated-libraries []
+  (reset! outdated-libs nil))
+
+(defn set-outdated-libs [configs]
   (let [library->latest-version (antq/library->latest-version configs true)
         libraries (lib/outdated-libs library->latest-version)]
-    (mapv #(c/fn-explorer-child-plain % true group #'select)
-          (sort (set/difference
-                  (set libraries)
-                  (set (shared/args groups group)))))))
+    (reset! outdated-libs libraries)))
+
+(defn select [{:keys [group]} groups {:keys [configs]}]
+  (when (-> outdated-libs deref nil?)
+    (set-outdated-libs configs))
+  (mapv #(c/fn-explorer-child-plain % true group #'select)
+      (sort (set/difference
+              (set @outdated-libs)
+              (set (shared/args groups group))))))

--- a/components/shell/src/polylith/clj/core/shell/jline.clj
+++ b/components/shell/src/polylith/clj/core/shell/jline.clj
@@ -1,7 +1,8 @@
 (ns ^:no-doc polylith.clj.core.shell.jline
   (:require [clojure.string :as str]
             [polylith.clj.core.util.interface.str :as str-util]
-            [polylith.clj.core.shell.candidate.engine :as engine])
+            [polylith.clj.core.shell.candidate.engine :as engine]
+            [polylith.clj.core.shell.candidate.selector.outdated-libs :as outdated-libs])
   (:import [org.jline.terminal TerminalBuilder]
            [org.jline.reader Completer]
            [org.jline.reader.impl DefaultParser]
@@ -73,13 +74,20 @@
       (Candidate. value display nil description suffix nil false)
       (Candidate. value display nil description nil nil true))))
 
+(defn reset-outdated-libs
+  "This is a hack, but the most straightforward way to solve the problem"
+  [parsed-line]
+  (let [line (.line parsed-line)]
+    (when (= "libs " line)
+      (outdated-libs/reset-outdated-libraries))))
+
 (defn ->completer []
   (proxy [Completer] []
     (complete [^LineReader _
                ^ParsedLine parsed-line
                ^java.util.List candidates]
-      (let [;line (.line parsed-line)
-            words (vec (.words parsed-line))]
+      (reset-outdated-libs parsed-line)
+      (let [words (vec (.words parsed-line))]
         (.addAll candidates (map candidate
                                  (engine/candidates words)))))))
 

--- a/components/version/src/polylith/clj/core/version/interface.clj
+++ b/components/version/src/polylith/clj/core/version/interface.clj
@@ -25,7 +25,7 @@
 (def minor 3)
 (def patch 0)
 (def revision SNAPSHOT) ;; Set to SNAPSHOT or RELEASE.
-(def snapshot 1) ;; Increase by one for every snapshot release, or set to 0 if a release.
+(def snapshot 2) ;; Increase by one for every snapshot release, or set to 0 if a release.
                   ;; Also update :snapshot-version: at the top of readme.adoc.
 (def snapshot? (= SNAPSHOT revision))
 
@@ -37,7 +37,7 @@
 
 (def tool (if system/extended? "polyx" "poly"))
 
-(def date "2025-09-30")
+(def date "2025-10-01")
 
 ;; Execute 'poly doc page:versions' to see when different changes was introduced.
 (def api-version {:breaking 1, :non-breaking 0})

--- a/next-release.md
+++ b/next-release.md
@@ -50,6 +50,7 @@ Main changes:
 - Add support for ClojureScript, issue [481](https://github.com/polyfy/polylith/issues/481) and PR [524](https://github.com/polyfy/polylith/pull/524)
 - Fix typo in the documentation, PR [560](https://github.com/polyfy/polylith/pull/560)
 - Fix reflection warnings, issue [563](https://github.com/polyfy/polylith/issues/563)
+- Remove lag when retrieving outdated libraries in the libs command, issue [568](https://github.com/polyfy/polylith/issues/568)
 
 ### Doc updates
 - Changed the sha for Sean's External test runner to `c97747aa2b1fdf03c46c7e435cca7c2608740a2a` in [this](https://cljdoc.org/d/polylith/clj-poly/0.3.0/doc/test-runners#_use_a_custom_test_runner) section.


### PR DESCRIPTION
Remove lag when retrieiving outdated libraries in the libs command, issue #568
Turn off dependabot warnings on example projects.
Version 0.3.0-SNAPSHOT 2