### PR TITLE
Fix npm scoped package handling in libs command

### DIFF
--- a/components/lib/src/polylith/clj/core/lib/core.clj
+++ b/components/lib/src/polylith/clj/core/lib/core.clj
@@ -24,12 +24,12 @@
         (latest-tools-deps-with-sizes-vec ws-dir entity-root-path libraries user-home)))
 
 
-(defn lib-deps [ws-dir ws-type deps package-deps top-namespace ns-to-lib lib->deps namespaces entity-root-path user-home]
+(defn lib-deps [ws-dir ws-type deps package-deps package-name top-namespace ns-to-lib lib->deps namespaces entity-root-path user-home]
   (if (= :toolsdeps1 ws-type)
     (ns-to-lib/lib-deps ws-dir top-namespace ns-to-lib lib->deps namespaces user-home)
     (util/stringify-and-sort-map
       (into {} (concat (latest-tools-deps-with-sizes-vec ws-dir entity-root-path deps user-home)
-                       (size-npm/with-sizes-vec ws-dir package-deps))))))
+                       (size-npm/with-sizes-vec ws-dir package-name package-deps))))))
 
 (defn lib->deps [ws-dir ws-type]
   (let [{:keys [deps]} (config-reader/read-development-config-files ws-dir ws-type)]
@@ -40,10 +40,11 @@
   (let [lib->deps (lib->deps ws-dir ws-type)
         src-deps (:deps deps-config)
         test-deps (get-in deps-config [:aliases :test :extra-deps])
+        package-name (:name package-config)
         package-src-deps (:dependencies package-config)
         package-test-deps (:devDependencies package-config)
-        src (lib-deps ws-dir ws-type src-deps package-src-deps top-namespace ns-to-lib lib->deps (:src namespaces) entity-root-path user-home)
-        test (lib-deps ws-dir ws-type test-deps package-test-deps top-namespace ns-to-lib lib->deps (:test namespaces) entity-root-path user-home)]
+        src (lib-deps ws-dir ws-type src-deps package-src-deps package-name top-namespace ns-to-lib lib->deps (:src namespaces) entity-root-path user-home)
+        test (lib-deps ws-dir ws-type test-deps package-test-deps package-name top-namespace ns-to-lib lib->deps (:test namespaces) entity-root-path user-home)]
     (cond-> {}
             (seq src) (assoc :src src)
             (seq test) (assoc :test test))))

--- a/components/lib/src/polylith/clj/core/lib/size_npm.clj
+++ b/components/lib/src/polylith/clj/core/lib/size_npm.clj
@@ -9,14 +9,27 @@
     (str ns "/" (name kw))
     (name kw)))
 
-(defn with-size [[lib version] node-modules-path]
-  (let [lib-name (keyword->full-name lib)]
+(defn- find-package-dir
+  "Find the npm package directory, checking workspace nested path first, then hoisted root.
+   With npm/yarn workspaces, dependencies may be nested under the workspace package
+   (e.g., node_modules/@poly/mantine/node_modules/@mantine/core) or hoisted to root."
+  [ws-dir package-name lib-name]
+  (let [nested-path (when package-name
+                      (str ws-dir "/node_modules/" package-name "/node_modules/" lib-name))
+        hoisted-path (str ws-dir "/node_modules/" lib-name)]
+    (cond
+      (and nested-path (file/exists nested-path)) nested-path
+      (file/exists hoisted-path) hoisted-path
+      :else hoisted-path)))
+
+(defn- with-size [[lib version] ws-dir package-name]
+  (let [lib-name (keyword->full-name lib)
+        pkg-dir (find-package-dir ws-dir package-name lib-name)]
     [lib-name
      {:version version
       :type "npm"
-      :size (file/directory-size (str node-modules-path "/" lib-name))}]))
+      :size (file/directory-size pkg-dir)}]))
 
-(defn with-sizes-vec [ws-dir libraries]
-  (let [node-module-path (str ws-dir "/node_modules")]
-    (mapv #(with-size  % node-module-path)
-          libraries)))
+(defn with-sizes-vec [ws-dir package-name libraries]
+  (mapv #(with-size % ws-dir package-name)
+        libraries))

--- a/components/lib/src/polylith/clj/core/lib/size_npm.clj
+++ b/components/lib/src/polylith/clj/core/lib/size_npm.clj
@@ -1,8 +1,16 @@
 (ns ^:no-doc polylith.clj.core.lib.size-npm
   (:require [polylith.clj.core.file.interface :as file]))
 
+(defn- keyword->full-name
+  "Convert a keyword to its full string name, preserving namespace for scoped npm packages.
+   For :@mantine/core, returns '@mantine/core' instead of just 'core'."
+  [kw]
+  (if-let [ns (namespace kw)]
+    (str ns "/" (name kw))
+    (name kw)))
+
 (defn with-size [[lib version] node-modules-path]
-  (let [lib-name (-> lib name str)]
+  (let [lib-name (keyword->full-name lib)]
     [lib-name
      {:version version
       :type "npm"


### PR DESCRIPTION
## Summary

  - Fix scoped npm packages (e.g., `@mantine/core`) showing incorrect latest versions in `poly libs :outdated`
  - Support npm/yarn workspaces when calculating package sizes

  ## Problem

  When using `poly libs :outdated`, npm packages with scoped names showed incorrect "latest" versions. For example:

  | library      | version  | latest  |
  |--------------|----------|---------|
  | charts       | ^8.3.8   | 0.0.3   |
  | core         | ^8.3.8   | 1.0.113 |

  The scope prefix was being stripped before querying the npm registry, causing lookups for unrelated packages (`core` instead of `@mantine/core`).

  Additionally, package size lookups failed for workspaces where dependencies are nested under the workspace package directory.

  ## Root Cause

  In Clojure, keywords containing `/` are interpreted as namespaced keywords. When `@mantine/core` from `package.json` becomes `:@mantine/core`:
  - `(namespace :@mantine/core)` → `"@mantine"`
  - `(name :@mantine/core)` → `"core"`

  Using `clojure.core/name` only returned the local name, dropping the scope.

  ## Solution

  1. Added `keyword->full-name` helper that preserves the namespace for scoped packages
  2. Updated npm registry queries to use full package names
  3. Added fallback logic for npm/yarn workspaces that checks both:
     - Nested: `node_modules/@poly/mantine/node_modules/@mantine/core`
     - Hoisted: `node_modules/@mantine/core`

  ## Files Changed

  - `components/antq/src/polylith/clj/core/antq/npm.clj`
  - `components/lib/src/polylith/clj/core/lib/size_npm.clj`
  - `components/lib/src/polylith/clj/core/lib/core.clj`