### PR TITLE
Reproduce another transitive deps issue

### DIFF
--- a/examples/transitive-lib-deps/components/brick3/deps.edn
+++ b/examples/transitive-lib-deps/components/brick3/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ ;; 'brick3' declares 'com.stuartsierra/component' implicityly via local-libs/lib-a, at an older version
+ ;; (0.2.0) than the one brick4 pulls in (1.0.0).
+ ;; In a project that has both bricks the direct 1.0.0 wins; a project with only
+ ;; brick3 ends up on the transitive 0.2.0.
+ :deps {local/lib-a {:local/root "../../local-libs/lib-a"}}
+ :aliases {:test {:extra-paths []
+                  :extra-deps {}}}}

--- a/examples/transitive-lib-deps/components/brick4/deps.edn
+++ b/examples/transitive-lib-deps/components/brick4/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {com.stuartsierra/component {:mvn/version "1.0.0"}}
+ :aliases {:test {:extra-paths []
+                  :extra-deps {}}}}

--- a/examples/transitive-lib-deps/deps.edn
+++ b/examples/transitive-lib-deps/deps.edn
@@ -2,6 +2,8 @@
 
                  :extra-deps {poly/brick1 {:local/root "components/brick1"}
                               poly/brick2 {:local/root "components/brick2"}
+                              poly/brick3 {:local/root "components/brick3"}
+                              poly/brick4 {:local/root "components/brick4"}
 
                               org.clojure/clojure {:mvn/version "1.12.0"}}}
 

--- a/examples/transitive-lib-deps/local-libs/lib-a/deps.edn
+++ b/examples/transitive-lib-deps/local-libs/lib-a/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src"]
+ :deps {com.stuartsierra/component {:mvn/version "0.1.0"}}
+ :aliases {:test {:extra-paths []
+                  :extra-deps {}}}}

--- a/examples/transitive-lib-deps/projects/project-c/deps.edn
+++ b/examples/transitive-lib-deps/projects/project-c/deps.edn
@@ -1,0 +1,7 @@
+{:deps {poly/brick3 {:local/root "../../components/brick3"}
+        poly/brick4 {:local/root "../../components/brick4"}
+
+        org.clojure/clojure {:mvn/version "1.12.0"}}
+
+ :aliases {:test {:extra-paths []
+                  :extra-deps  {}}}}

--- a/examples/transitive-lib-deps/projects/project-d/deps.edn
+++ b/examples/transitive-lib-deps/projects/project-d/deps.edn
@@ -1,0 +1,6 @@
+{:deps {poly/brick3 {:local/root "../../components/brick4"}
+        
+        org.clojure/clojure {:mvn/version "1.12.0"}}
+
+ :aliases {:test {:extra-paths []
+                  :extra-deps  {}}}}

--- a/examples/transitive-lib-deps/workspace.edn
+++ b/examples/transitive-lib-deps/workspace.edn
@@ -10,4 +10,6 @@
                                            :exclude []}}
  :projects {"development" {:alias "dev"}
             "project-a"   {:alias "a" :necessary ["brick1" "brick2"]}
-            "project-b"   {:alias "b" :necessary ["brick1"]}}}
+            "project-b"   {:alias "b" :necessary ["brick1"]}
+            "project-c"   {:alias "c" :necessary ["brick3" "brick4"]}
+            "project-d"   {:alias "d" :necessary ["brick3"]}}}


### PR DESCRIPTION
The transitive option doesn't detect the transitive dep of `com.stuartsierra/component 0.1.0` in project C:

```
clojure -M:poly libs :transitive libraries:com.stuartsierra/component
                                                                      b  b  b  b
                                                                      r  r  r  r
                                                                      i  i  i  i
                                                                      c  c  c  c
                                                                      k  k  k  k
  library                     version  type   KB   a  b  c  d   dev   1  2  3  4
  ----------------------------------------------   ----------   ---   ----------
  com.stuartsierra/component  0.2.3    maven  16   x  x  -  -    x    x  .  .  .
  com.stuartsierra/component  1.0.0    maven  18   -  -  x  x    -    .  .  .  x
```

Project C tree
```
clj  -Stree
org.clojure/clojure 1.12.0
  . org.clojure/spec.alpha 0.5.238
  . org.clojure/core.specs.alpha 0.4.74
poly/brick3 /Users/jeroen/Projects/Github/polyfy/polylith/examples/transitive-lib-deps/components/brick3
  . local/lib-a /Users/jeroen/Projects/Github/polyfy/polylith/examples/transitive-lib-deps/local-libs/lib-a
    X com.stuartsierra/component 0.1.0 :older-version
poly/brick4 /Users/jeroen/Projects/Github/polyfy/polylith/examples/transitive-lib-deps/components/brick4
  . com.stuartsierra/component 1.0.0
    . com.stuartsierra/dependency 1.0.0
```

Project D Tree
```
clj  -Stree
org.clojure/clojure 1.12.0
  . org.clojure/spec.alpha 0.5.238
  . org.clojure/core.specs.alpha 0.4.74
poly/brick3 /Users/jeroen/Projects/Github/polyfy/polylith/examples/transitive-lib-deps/components/brick4
  . com.stuartsierra/component 1.0.0
    . com.stuartsierra/dependency 1.0.0
```